### PR TITLE
Provide has() method to Document

### DIFF
--- a/src/Prismic/Document.php
+++ b/src/Prismic/Document.php
@@ -97,6 +97,16 @@ class Document
 
         return $single;
     }
+    
+    /**
+     * @param string $field
+     *
+     * @return bool
+     * */
+     public function has($field)
+     {
+         return array_key_exists($field, $this->fragments);
+     }
 
     /**
      * @param string $field


### PR DESCRIPTION
This will provide a way to test for the presence of a fragment, and prevent the "Undefined variable $single" error that's thrown by the get() method when the fragment doesn't exist.
