### PR TITLE
Turn newline characters into br tags in HTML, except in pre

### DIFF
--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -128,19 +128,19 @@ class StructuredText implements FragmentInterface
     public static function asHtmlBlock($block, $linkResolver = null)
     {
         if ($block instanceof HeadingBlock) {
-            return '<h' . $block->getLevel() . '>' .
+            return nl2br('<h' . $block->getLevel() . '>' .
                     StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) .
-                    '</h' . $block->getLevel() . '>';
+                    '</h' . $block->getLevel() . '>');
         } elseif ($block instanceof ParagraphBlock) {
-            return '<p>' .
-                   StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) . '</p>';
+            return nl2br('<p>' .
+                   StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) . '</p>');
         } elseif ($block instanceof ListItemBlock) {
-            return '<li>' .
-                   StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) . '</li>';
+            return nl2br('<li>' .
+                   StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) . '</li>');
         } elseif ($block instanceof ImageBlock) {
-            return '<p>' . $block->getView()->asHtml($linkResolver) . '</p>';
+            return nl2br('<p>' . $block->getView()->asHtml($linkResolver) . '</p>');
         } elseif ($block instanceof EmbedBlock) {
-            return $block->getObj()->asHtml();
+            return nl2br($block->getObj()->asHtml());
         } elseif ($block instanceof PreformattedBlock) {
             return '<pre>' .
                    StructuredText::asHtmlText($block->getText(), $block->getSpans(), $linkResolver) .

--- a/src/Prismic/Fragment/Text.php
+++ b/src/Prismic/Fragment/Text.php
@@ -22,7 +22,7 @@ class Text implements FragmentInterface
 
     public function asHtml($linkResolver = null)
     {
-        return '<span class="text">' . htmlentities($this->value) . '</span>';
+        return '<span class="text">' . nl2br(htmlentities($this->value)) . '</span>';
     }
 
     public function asText()

--- a/tests/Prismic/DocumentTest.php
+++ b/tests/Prismic/DocumentTest.php
@@ -34,7 +34,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($this->document->getText('product.name'), 'Cool Coconut Macaron');
         $this->assertEquals($this->document->getText('product.short_lede'), 'An island of flavours');
-        $this->assertEquals($this->document->getText('product.allergens'), 'Fruit');
+        $this->assertEquals($this->document->getText('product.allergens'), "Fruit\nCats");
         $this->assertEquals($this->document->getText('product.price'), '2.5');
     }
 
@@ -105,6 +105,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->document->getHtml('product.price'), '<span class="number">2.5</span>');
         $this->assertEquals($this->document->getHtml('product.adult'), '<span class="text">yes</span>');
         $this->assertEquals($this->document->getHtml('product.birthdate'), '<time>2013-10-23</time>');
+        $this->assertRegExp('`Fruit\s*<br\s*/?>\s*Cats`s', $this->document->getHtml('product.allergens'));
         //TODO
     }
 

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -18,7 +18,7 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFirstParagraph()
     {
-        $content = "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.";
+        $content = "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes.\nThis is after a new line. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.";
         $this->assertEquals($content, $this->structuredText->getFirstParagraph()->getText());
     }
 
@@ -29,7 +29,7 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
 
     public function testGetFirstPreformatted()
     {
-        $content = "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.";
+        $content = "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes.\nThis is after a new line. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.";
         $this->assertEquals($content, $this->structuredText->getFirstPreformatted()->getText());
     }
 
@@ -68,6 +68,14 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($content, $structuredText->asHtml());
     }
 
+    public function testPreformattedBlockHtmlHasNoExtraBreakTags()
+    {
+        $text = "This pre block has\ntwo lines and a break tag shouldn't be added.";
+        $bloc = new \Prismic\Fragment\Block\PreformattedBlock($text, array(), null);
+        $structuredText = new \Prismic\Fragment\StructuredText(array($bloc));
+        $this->assertRegExp('/block has\ntwo lines/', $structuredText->asHtml());
+    }
+
     public function testDocumentLinkRendering()
     {
         $linkResolver = new FakeLinkResolver();
@@ -85,7 +93,7 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
         $notSection = '([^<]|<[^\/]|<\/[^s]|<\/s[^e]|<\/se[^c]|<\/sec[^t]|<\/sect[^i]|' .
                       '<\/secti[^o]|<\/sectio[^n]|<\/section[^>])';
         $html = preg_replace(
-            '/.*(<section data-field="product.listLinks">' . $notSection . '*<\/section>).*/',
+            '/.*(<section data-field="product.listLinks">' . $notSection . '*<\/section>).*/s',
             '$1',
             $this->document->asHtml($linkResolver)
         );
@@ -101,4 +109,10 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
         $content = '<p><a href="http://host/document/UjHkUrGIJ7cBlWAb">link1</a></p>';
         $this->assertEquals($content, $structuredText->asHtml($linkResolver));
     }
+
+    public function testStructuredTextHtmlHasBreakTags()
+    {
+        $this->assertRegExp('`can be rough sometimes\.\s*<br\s*/?>\s*This is after a new line\.`s', $this->structuredText->asHtml());
+    }
+
 }

--- a/tests/fixtures/search.json
+++ b/tests/fixtures/search.json
@@ -38,12 +38,12 @@
                     "value": [
                         {
                             "type": "paragraph",
-                            "text": "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.",
+                            "text": "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes.\nThis is after a new line. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.",
                             "spans": []
                         },
                         {
                             "type": "preformatted",
-                            "text": "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.",
+                            "text": "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes.\nThis is after a new line. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.",
                             "spans": []
                         },
                         {
@@ -188,7 +188,7 @@
                 },
                 "allergens": {
                     "type": "Text",
-                    "value": "Fruit"
+                    "value": "Fruit\nCats"
                 },
                 "birthdate": {
                     "type": "Date",


### PR DESCRIPTION
This patch runs nl2br over the HTML returned in Text and StructuredText's to
HTML methods, except in preformatted text.

Tests are included (the search fixture had to be changed and some unrelated
tests tweaked to accommodate those changes).
