### PR TITLE
added __toString() to Prismic\Ref

### DIFF
--- a/src/Prismic/Ref.php
+++ b/src/Prismic/Ref.php
@@ -52,6 +52,11 @@ class Ref
         return $this->maybeScheduledAt;
     }
 
+    public function __toString()
+    {
+        return (string) $this->getRef();
+    }
+
     public static function parse($json)
     {
         return new Ref(


### PR DESCRIPTION
if I understand things properly, in the end a Ref is supposed to map to a string
