### PR TITLE
Removing useless attribute in preformatted

### DIFF
--- a/src/Prismic/Fragment/Block/PreformattedBlock.php
+++ b/src/Prismic/Fragment/Block/PreformattedBlock.php
@@ -23,7 +23,6 @@ class PreformattedBlock implements TextInterface
      * @var array an array of \Prismic\Fragment\Span\SpanInterface objects that contain the formatting (em, strong, links, ...)
      */
     private $spans;
-    private $level;
 
     /**
      * Constructs a paragraph block.
@@ -31,11 +30,10 @@ class PreformattedBlock implements TextInterface
      * @param string   $text      the unformatted text
      * @param array    $spans     an array of \Prismic\Fragment\Span\SpanInterface objects that contain the formatting (em, strong, links, ...)
      */
-    public function __construct($text, $spans, $level)
+    public function __construct($text, $spans)
     {
         $this->text = $text;
         $this->spans = $spans;
-        $this->level = $level;
     }
 
     /**
@@ -62,8 +60,4 @@ class PreformattedBlock implements TextInterface
         return $this->spans;
     }
 
-    public function getLevel()
-    {
-        return $this->level;
-    }
 }

--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -358,7 +358,7 @@ class StructuredText implements FragmentInterface
         }
 
         if ($json->type == 'preformatted') {
-            return new PreformattedBlock($json->text, $json->spans, false);
+            return new PreformattedBlock($json->text, $json->spans);
         }
 
         return null;


### PR DESCRIPTION
Just making sure I'm not missing something, but I think this attribute in `PreformattedBlock` was useless, and was the result of a copy-paste from `HeadingBlock`. The other kits don't have it. Please make sure I'm not crazy though before merging! ;)
