### PR TITLE
Heading blocks and first heading can be fetched from StructuredText.

### DIFF
--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -91,6 +91,20 @@ class StructuredText implements FragmentInterface
         });
     }
 
+    public function getFirstHeading()
+    {
+        $blocks = $this->getHeadings();
+
+        return reset($blocks);
+    }
+
+    public function getHeadings()
+    {
+        return array_filter($this->blocks, function ($block) {
+            return ($block instanceof HeadingBlock);
+        });
+    }
+
     public function asHtml($linkResolver = null)
     {
         $groups = array();

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -50,6 +50,17 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $this->structuredText->getPreformatted());
     }
 
+    public function testGetFirstHeading()
+    {
+        $content = "A heading followed by a preformatted text";
+        $this->assertEquals($content, $this->structuredText->getFirstHeading()->getText());
+    }
+
+    public function testGetHeadings()
+    {
+        $this->assertCount(1, $this->structuredText->getHeadings());
+    }
+
     public function testPreformattedBlockFormatRendering()
     {
         $text = "This is a test.";

--- a/tests/fixtures/search.json
+++ b/tests/fixtures/search.json
@@ -42,6 +42,11 @@
                             "spans": []
                         },
                         {
+                            "type": "heading1",
+                            "text": "A heading followed by a preformatted text",
+                            "spans": []
+                        },
+                        {
                             "type": "preformatted",
                             "text": "If you ever met coconut taste on its bad day, you surely know that coconut, coming from bad-tempered islands, can be rough sometimes.\nThis is after a new line. That is why we like to soften it with a touch of caramel taste in its ganache. The result is the perfect encounter between the finest palm fruit and the most tasty of sugarcane's offspring.",
                             "spans": []


### PR DESCRIPTION
In addition to my previous [PR](https://github.com/prismicio/php-kit/pull/38), now you can also fetch all HeadingBlock types from a StructuredText instance.
