### PR TITLE
Made the client instance overridable.

### DIFF
--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -243,7 +243,7 @@ class SearchForm
             if ($response) {
                 return $response;
             } else {
-                $request = Api::defaultClient()->get($url);
+                $request = $this->api->getClient()->get($url);
                 $response = $request->send();
                 $cacheControl = $response->getHeaders()->get('Cache-Control');
                 $cacheDuration = null;

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -49,6 +49,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $api = Api::get('don\'t care about this value', null, $client);
 
         $this->assertInstanceOf('Prismic\Api', $api);
+        $this->assertEquals($client, $api->getClient());
 
         return $api;
     }


### PR DESCRIPTION
I have made the client overridable so users can inject their own Guzzle instance. They also can access the current client instance with the getClient() method. I saw in the code that you've made some sort of base for the functionality and I build this PR on top of it.

The main reason this functionality is important for me is to have some sort of mocking functionality in the (coming soon) SymfonyBundle tests.
