### PR TITLE
ttl vs absolute timestamp

### DIFF
--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -255,7 +255,7 @@ class SearchForm
                     throw new \RuntimeException("Unable to decode json response");
                 }
                 if ($cacheDuration !== null) {
-                    $expiration = time() + $cacheDuration;
+                    $expiration = $cacheDuration;
                     $this->api->getCache()->set($url, $json, $expiration);
                 }
 


### PR DESCRIPTION
Hello,

I think there is a little problem at line 258.
The third argument of cache->set() is a ttl, so $expiration must be set to a ttl, and not to a absolute timestamp. This can lead to caching problems, because ttl is set to 2014 - 1970 + 10 years (from cache-control header) = 54 years, that is a too high ttl for some caching systems.

Cheers,

Pierre
