### PR TITLE
Expose the data we're about the submit as read-only array.

### DIFF
--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -54,6 +54,16 @@ class SearchForm
     }
 
     /**
+     * Get the parameters we're about to submit.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
      * Sets a value for a given parameter. For instance: set('orderings', '[product.price]'),
      * or set('page', 2).
      *


### PR DESCRIPTION
A small PR to expose the data we're about the submit as read-only array. This way the full query is readable from outside the SearchForm class (read outside of the SDK).
