### PR TITLE
Fix for issue `Fatal error:  Call to undefined method stdClass::getEnd()...

### DIFF
--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -568,7 +568,9 @@ class StructuredText implements FragmentInterface
         }
 
         if ($json->type == 'preformatted') {
-            return new PreformattedBlock($json->text, $json->spans, $label);
+            $p = StructuredText::parseText($json);
+
+            return new PreformattedBlock($json->text, $p->getSpans(), $label);
         }
 
         return null;

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -199,4 +199,17 @@ class StructuredTextTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSpanInPreformattedTextIsCorrectlyParsedAsSpan()
+    {
+        $structuredText = $this->document->getStructuredText('product.span_in_pre');
+        $this->assertEquals(
+            'This is some preformatted text containing a span',
+            $structuredText->asText()
+        );
+        $this->assertEquals(
+            '<pre><strong>This</strong> is some preformatted text containing a span</pre>',
+            $structuredText->asHtml()
+        );
+    }
+
 }

--- a/tests/fixtures/search.json
+++ b/tests/fixtures/search.json
@@ -595,6 +595,22 @@
                             ]
                         }
                     ]
+                },
+                "span_in_pre" : {
+                    "type": "StructuredText",
+                    "value": [
+                        {
+                            "type": "preformatted",
+                            "text": "This is some preformatted text containing a span",
+                            "spans": [
+                                {
+                                    "start": 0,
+                                    "end": 4,
+                                    "type": "strong"
+                                }
+                            ]
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
Fix for issue `Fatal error:  Call to undefined method stdClass::getEnd() in Prismic/Fragment/StructuredText.php on line 378`

If there's some reason why there shouldn't be spans in pre formatted blocks, then the spans should probably be discarded with `return new PreformattedBlock($json->text, array(), $label);` ??
