### PR TITLE
Throw RuntimeException for missing ref in search form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.3",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzle/guzzle": "3.9.1"
+        "guzzle/guzzle": ">=3.9.1"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "dev-master",


### PR DESCRIPTION
If you forget to set the ref for a search form, you'll get a 400 Error from the api for 'Bad Request'. By first checking existence of a ref before sending the request there's a clearer reason as to what went wrong and an HTTP request is saved.
