### PR TITLE
Make guzzle version a little more flexible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.3",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzle/guzzle": "3.9.1"
+        "guzzle/guzzle": ">=3.9.1"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "dev-master",


### PR DESCRIPTION
Guzzle needed to be exactly 3.9.1. Now it is >=3.9.1

This was causing an unresolvable dependency clash with a local project that was also using a fixed constraint. Fixed our own project, but it would be good to fix here too before another dependency comes along with this problem. ;)

Note that this will never result in Guzzle being upgraded beyond the 3.x series, because the Github repo and Packagist locations both changed. To upgrade to 4.x or higher will require changing the package name to guzzlehttp/guzzle.
