### PR TITLE
Cache keys are too long for memcached which limits length to 250 bytes

### DIFF
--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -248,8 +248,9 @@ class SearchForm
         ) {
             $url = $this->form->getAction() . '?' . http_build_query($this->data);
             $url = preg_replace('/%5B(?:[0-9]|[1-9][0-9]+)%5D=/', '=', $url);
+            $cacheKey = md5($url);
 
-            $response = $this->api->getCache()->get($url);
+            $response = $this->api->getCache()->get($cacheKey);
 
             if ($response) {
                 return $response;
@@ -267,7 +268,7 @@ class SearchForm
                 }
                 if ($cacheDuration !== null) {
                     $expiration = $cacheDuration;
-                    $this->api->getCache()->set($url, $json, $expiration);
+                    $this->api->getCache()->set($cacheKey, $json, $expiration);
                 }
 
                 return $json;

--- a/tests/Prismic/LesBonnesChosesTest.php
+++ b/tests/Prismic/LesBonnesChosesTest.php
@@ -22,7 +22,7 @@ class LesBonnesChosesTest extends \PHPUnit_Framework_TestCase
     {
         $api = Api::get(self::$testRepository);
         $nbRefs = count($api->getData()->getRefs());
-        $this->assertEquals($nbRefs, 1);
+        $this->assertEquals($nbRefs, 3);
     }
 
     /* Tests to calling the API */
@@ -116,7 +116,7 @@ class LesBonnesChosesTest extends \PHPUnit_Framework_TestCase
         $fakeResponse->next_page = NULL;
         $fakeResponse->prev_page = NULL;
 
-        \apc_store('http://lesbonneschoses.prismic.io/api/documents/search?page=1&pageSize=20&ref=UlfoxUnM08QWYXdl', $fakeResponse, 1000);
+        \apc_store(md5('http://lesbonneschoses.prismic.io/api/documents/search?page=1&pageSize=20&ref=UlfoxUnM08QWYXdl'), $fakeResponse, 1000);
 
         $results2 = $api->forms()->everything->ref($masterRef)->submit();
 


### PR DESCRIPTION
If you use memcached as a cache backend the search form URLs along with the token exceed the maximum length allowed for a key.
