### PR TITLE
Incorrect predicate function name for date before/after

### DIFF
--- a/src/Prismic/Predicates.php
+++ b/src/Prismic/Predicates.php
@@ -47,14 +47,14 @@ class Predicates {
         if ($before instanceof DateTime) {
             $before = $before->getTimestamp() * 1000;
         }
-        return new SimplePredicate("date.date-before", $fragment, array($before));
+        return new SimplePredicate("date.before", $fragment, array($before));
     }
 
     public static function dateAfter($fragment, $after) {
         if ($after instanceof DateTime) {
             $after = $after->getTimestamp() * 1000;
         }
-        return new SimplePredicate("date.date-after", $fragment, array($after));
+        return new SimplePredicate("date.after", $fragment, array($after));
     }
 
     public static function dateBetween($fragment, $before, $after) {


### PR DESCRIPTION
It would seem that the api function names (?) for date.before and date.after were incorrect. Sorry there's no test, but I've no time right now. I haven't checked the other operators/methods but I'm guessing that "date.date-between" should be "date.between" also.
