### PR TITLE
<datetime> is not a valid element, it should be <time>

### DIFF
--- a/src/Prismic/Fragment/Timestamp.php
+++ b/src/Prismic/Fragment/Timestamp.php
@@ -55,7 +55,12 @@ class Timestamp implements FragmentInterface
      */
     public function asHtml($linkResolver = null)
     {
-        return '<datetime>' . htmlentities($this->value) . '</datetime>';
+        $datetime = $this->asDateTime()->format('c');
+
+        return sprintf('<time datetime="%s">%s</time>',
+            $datetime,
+            htmlentities($this->value)
+        );
     }
 
     /**

--- a/tests/Prismic/DocumentTest.php
+++ b/tests/Prismic/DocumentTest.php
@@ -147,7 +147,7 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $timestampFragment = $this->document->getTimestamp('product.publication_time');
         $this->assertEquals($timestampFragment->asText(), '2014-06-18T15:30:00+0000');
         $this->assertEquals($timestampFragment->getValue(), '2014-06-18T15:30:00+0000');
-        $this->assertEquals($timestampFragment->asHtml(), '<datetime>2014-06-18T15:30:00+0000</datetime>');
+        $this->assertEquals($timestampFragment->asHtml(), '<time datetime="2014-06-18T15:30:00+00:00">2014-06-18T15:30:00+0000</time>');
         $dateTime = $timestampFragment->asDateTime();
         $this->assertEquals($dateTime->getTimestamp(), 1403105400);
     }


### PR DESCRIPTION
`Timestamp::asHtml()` returns an invalid element <datetime> so I changed it to time, and thought I might as well add the 'datetime' attribute to it whilst I was there...
