### PR TITLE
Fix undefined offset notice in GroupDoc

### DIFF
--- a/src/Prismic/Fragment/GroupDoc.php
+++ b/src/Prismic/Fragment/GroupDoc.php
@@ -20,7 +20,7 @@ class GroupDoc extends WithFragments implements ArrayAccess
 
     public function offsetExists($offset)
     {
-        return $offset >= 0 && $offset < count($this->getFragments());
+        return $this->has($offset);
     }
 
     public function offsetGet($offset)

--- a/tests/Prismic/GroupDocTest.php
+++ b/tests/Prismic/GroupDocTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Prismic\Test;
+
+use Prismic\Document;
+use Prismic\Fragment\Group;
+
+class GroupDocTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected function setUp()
+    {
+        $json = json_decode(file_get_contents(__DIR__.'/../fixtures/group.json'));
+        $this->document = Document::parse($json[0]);
+    }
+
+    public function testDocumentIsAvailable()
+    {
+        $this->assertInstanceOf('Prismic\Document', $this->document);
+        return $this->document;
+    }
+
+    /**
+     * @depends testDocumentIsAvailable
+     */
+    public function testDocumentHasGroupFragment(Document $doc)
+    {
+        $fragment = $doc->get('article.group_frag');
+        $this->assertInstanceOf('\Prismic\Fragment\Group', $fragment);
+
+        return $fragment;
+    }
+
+    /**
+     * @depends testDocumentHasGroupFragment
+     */
+    public function testGroupDocIsReturnedByGetArray(Group $group)
+    {
+        $array = $group->getArray();
+        $this->assertCount(3, $array);
+        foreach($array as $groupDoc) {
+            $this->assertInstanceOf('\Prismic\Fragment\GroupDoc', $groupDoc);
+        }
+
+        return $array;
+    }
+
+    /**
+     * @depends testDocumentHasGroupFragment
+     */
+    public function testOffsetExists(Group $group)
+    {
+        foreach($group->getArray() as $groupDoc) {
+            $this->assertInternalType('bool', $groupDoc->has('element_three'));
+            $this->assertTrue($groupDoc->has('element_one'));
+            $this->assertFalse($groupDoc->has('something_else'));
+
+            $this->assertTrue( isset($groupDoc['element_one']) );
+            $this->assertFalse( isset($groupDoc['something_else']) );
+        }
+
+        return $group;
+    }
+
+    /**
+     * @depends testOffsetExists
+     */
+    public function testOffsetGet(Group $group)
+    {
+        foreach($group->getArray() as $groupDoc) {
+            $this->assertInstanceOf('\Prismic\Fragment\Text', $groupDoc['element_one']);
+        }
+    }
+
+
+
+}

--- a/tests/fixtures/group.json
+++ b/tests/fixtures/group.json
@@ -1,0 +1,46 @@
+[
+    {
+        "id": "UinbYMuvzesP4mix",
+        "type": "article",
+        "href": "http://lesbonneschoses-uinbymuvzesp4mie.prismic.io/api/documents/search?ref=UjnQi8uvzXIAAYEM&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22UinbYMuvzesP4mix%22%29+%5D%5D",
+        "tags": [],
+        "slugs": [
+            "about-us"
+        ],
+        "data": {
+            "article": {
+                "group_frag": {
+                    "type": "Group",
+                    "value": [
+                        {
+                            "element_one" : {
+                              "type": "Text",
+                              "value" : "Element One"
+                            }
+                        },
+                        {
+                            "element_one" : {
+                              "type": "Text",
+                              "value" : "Element One"
+                            },
+                            "element_two" : {
+                              "type": "Text",
+                              "value" : "Element Two"
+                            }
+                        },
+                        {
+                            "element_one" : {
+                              "type": "Text",
+                              "value" : "Element One"
+                            },
+                            "element_three" : {
+                              "type": "Text",
+                              "value" : "Element Three"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
``` php
$group = $document->getGroup('article.group_name');
foreach($group->getArray() as $groupDoc) {
  if(isset($groupDoc['something'])) {
    // echo $groupDoc['something']->asText();
  }
}
```

This will raise a notice "undefined offset 'something' in GroupDoc on line ..." which shouldn't really happen if we're first testing to see if the index exists in the first place...
