### PR TITLE
SearchForm#set: return self

### DIFF
--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -84,24 +84,20 @@ class SearchForm
             if (is_int($value) && $field->getType() != "Integer") {
                 throw new \RuntimeException("Cannot use a Int as value for field " . $key);
             } else {
-                $data = $this->data;
                 if ($field->isMultiple()) {
-                    $values = isset($data[$key]) ? $data[$key] : array();
+                    $values = isset($this->data[$key]) ? $this->data[$key] : array();
                     if (is_array($values)) {
                         array_push($values, $value);
                     } else {
                         $values = array($value);
                     }
-                    $data[$key] = $values;
+                    $this->data[$key] = $values;
                 } else {
-                    $data[$key] = $value;
+                    $this->data[$key] = $value;
                 }
             }
-
-            return new SearchForm($this->api, $this->form, $data);
-        } else {
-            return null;
         }
+        return $this;
     }
 
     /**
@@ -128,10 +124,9 @@ class SearchForm
      */
     public function pageSize($pageSize)
     {
-        $data = $this->data;
-        $data['pageSize'] = $pageSize;
+        $this->data['pageSize'] = $pageSize;
 
-        return new SearchForm($this->api, $this->form, $data);
+        return $this;
     }
 
     /**
@@ -143,10 +138,9 @@ class SearchForm
      */
     public function page($page)
     {
-        $data = $this->data;
-        $data['page'] = $page;
+        $this->data['page'] = $page;
 
-        return new SearchForm($this->api, $this->form, $data);
+        return $this;
     }
 
     /**
@@ -158,10 +152,9 @@ class SearchForm
      */
     public function orderings($orderings)
     {
-        $data = $this->data;
-        $data['orderings'] = $orderings;
+        $this->data['orderings'] = $orderings;
 
-        return new SearchForm($this->api, $this->form, $data);
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This is is a fix to various methods of SearchForm to return the current instance rather than a new one, as per its own documentation.

The bug report I was going to submit follows:

------

I'm building up a search form, predicate by predicate. I like to do this on separate lines of code, since that makes it easy to wrap some lines in conditionals, for example.

I got caught up just now because the query method returns a new instance rather than modifying and returning itself, due to the set method doing that.

Presuming I do want to split it into separate lines, instead of being able to do
```
$form = $api->forms()->everything;
$form->ref($api->master());
$form->query(Predicate::....);
$form->query(Predicate::...);
$result = $form->submit();
```

I have to do
```
$form = $api->forms()->everything;
$form = $form->ref($api->master());
$form = $form->query(Predicate::...);
$form = $form->query(Predicate::...);
$result = $form->submit();
```
which seems very awkward.

Even the documentation of $searchForm->set() (which both of these methods use) suggests it modifies the existing object, but in fact it doesn't. https://github.com/prismicio/php-kit/blob/master/src/Prismic/SearchForm.php#L66

```
    /**
     * Sets a value for a given parameter. For instance: set('orderings', '[product.price]'),
     * or set('page', 2).
     *
     * Checks that the parameter is expected in the RESTful form before allowing to add it.
     *
     * @api
     * @param  string $key the name of the parameter
     * @param  string $value the value of the parameter
     * @throws \RuntimeException
     * @return \Prismic\SearchForm the current SearchForm object, with the new parameter added
     */
```
"return the current SearchForm object" -- this is not what it does. It'd be a lot more useful if it did.

Incidentally, there's a case where currently it returns null. I wonder if this should in fact be throwing an exception or returning the unmodified $this.