### PR TITLE
Reconcile CacheInterface docs with implementations and test

### DIFF
--- a/src/Prismic/Cache/CacheInterface.php
+++ b/src/Prismic/Cache/CacheInterface.php
@@ -29,7 +29,7 @@ interface CacheInterface
      * @api
      *
      * @param  string    $key the key of the cache entry
-     * @return \stdClass the value of the entry, as it was passed to CacheInterface::set, null if not present in cache
+     * @return mixed the value of the entry, as it was passed to CacheInterface::set, null if not present in cache
      */
     public function get($key);
 
@@ -41,6 +41,7 @@ interface CacheInterface
      * @param string    $key   the key of the cache entry
      * @param \stdClass $value the value of the entry
      * @param integer   $ttl   the time until this cache entry expires
+     * @return void
      */
     public function set($key, $value, $ttl = 0);
 
@@ -50,6 +51,7 @@ interface CacheInterface
      * @api
      *
      * @param string $key the key of the cache entry
+     * @return void
      */
     public function delete($key);
 
@@ -57,6 +59,8 @@ interface CacheInterface
      * Clears the whole cache
      *
      * @api
+     *
+     * @return void
      */
     public function clear();
 }

--- a/src/Prismic/Cache/DefaultCache.php
+++ b/src/Prismic/Cache/DefaultCache.php
@@ -22,11 +22,15 @@ class DefaultCache implements CacheInterface
      * @api
      *
      * @param  string    $key the key of the cache entry
-     * @return \stdClass the value of the entry
+     * @return mixed the value of the entry, as it was passed to CacheInterface::set, null if not present in cache
      */
     public function get($key)
     {
-        return \apc_fetch($key);
+        $value = \apc_fetch($key, $success);
+        if (!$success) {
+            return null;
+        }
+        return $value;
     }
 
     /**
@@ -37,10 +41,11 @@ class DefaultCache implements CacheInterface
      * @param string    $key   the key of the cache entry
      * @param \stdClass $value the value of the entry
      * @param integer   $ttl   the time until this cache entry expires
+     * @return void
      */
     public function set($key, $value, $ttl = 0)
     {
-        return \apc_store($key, $value, $ttl);
+        \apc_store($key, $value, $ttl);
     }
 
     /**
@@ -49,19 +54,22 @@ class DefaultCache implements CacheInterface
      * @api
      *
      * @param string $key the key of the cache entry
+     * @return void
      */
     public function delete($key)
     {
-        return \apc_delete($key);
+        \apc_delete($key);
     }
 
     /**
      * Clears the whole cache
      *
      * @api
+     *
+     * @return void
      */
     public function clear()
     {
-        return \apc_clear_cache("user");
+        \apc_clear_cache("user");
     }
 }

--- a/src/Prismic/Cache/NoCache.php
+++ b/src/Prismic/Cache/NoCache.php
@@ -25,11 +25,11 @@ class NoCache implements CacheInterface
      * @api
      *
      * @param  string    $key the key of the cache entry
-     * @return \stdClass the value of the entry
+     * @return mixed the value of the entry, as it was passed to CacheInterface::set, null if not present in cache
      */
     public function get($key)
     {
-        return false;
+        return null;
     }
 
     /**
@@ -40,10 +40,10 @@ class NoCache implements CacheInterface
      * @param string    $key   the key of the cache entry
      * @param \stdClass $value the value of the entry
      * @param integer   $ttl   the time until this cache entry expires
+     * @return void
      */
     public function set($key, $value, $ttl = null)
     {
-        return false;
     }
 
     /**
@@ -52,19 +52,20 @@ class NoCache implements CacheInterface
      * @api
      *
      * @param string $key the key of the cache entry
+     * @return void
      */
     public function delete($key)
     {
-        return false;
     }
 
     /**
      * Clears the whole cache
      *
      * @api
+     *
+     * @return void
      */
     public function clear()
     {
-        return false;
     }
 }

--- a/tests/Prismic/CacheTest.php
+++ b/tests/Prismic/CacheTest.php
@@ -22,7 +22,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->cache->set('key', 'value');
         $this->assertEquals($this->cache->get('key'), 'value');
         $this->cache->delete('key');
-        $this->assertFalse($this->cache->get('key'));
+        $this->assertNull($this->cache->get('key'));
     }
 
     public function testSetValueClear()
@@ -34,8 +34,8 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->cache->get('key1'), 'value1');
         $this->assertEquals($this->cache->get('key2'), 'value2');
         $this->cache->clear();
-        $this->assertFalse($this->cache->get('key'));
-        $this->assertFalse($this->cache->get('key1'));
-        $this->assertFalse($this->cache->get('key2'));
+        $this->assertNull($this->cache->get('key'));
+        $this->assertNull($this->cache->get('key1'));
+        $this->assertNull($this->cache->get('key2'));
     }
 }


### PR DESCRIPTION
This fixes https://github.com/prismicio/php-kit/issues/82 which,
though closed, is not fixed before this patch.