### PR TITLE
Add CacheInterface#has method

### DIFF
--- a/src/Prismic/Cache/CacheInterface.php
+++ b/src/Prismic/Cache/CacheInterface.php
@@ -13,7 +13,7 @@ namespace Prismic\Cache;
 /**
  * This is the interface you're supposed to implement if you want to
  * use your own caching strategy with the kit.
- * The way it works is pretty simple: implement the 4 methods with your
+ * The way it works is pretty simple: implement the methods with your
  * implementation, and pass an instance of your class as the $cache parameter
  * in your Prismic\Api::get call.
  * Two implementations are included in the PHP kit out-of-the-box:
@@ -23,6 +23,16 @@ namespace Prismic\Cache;
  */
 interface CacheInterface
 {
+    /**
+     * Tests whether the cache has a value for a particular key
+     *
+     * @api
+     *
+     * @param string $key the key of the cache entry
+     * @return boolean true if the cache has a value for this key, otherwise false
+     */
+    public function has($key);
+
     /**
      * Returns the value of a cache entry from its key
      *

--- a/src/Prismic/Cache/DefaultCache.php
+++ b/src/Prismic/Cache/DefaultCache.php
@@ -17,6 +17,19 @@ namespace Prismic\Cache;
 class DefaultCache implements CacheInterface
 {
     /**
+     * Tests whether the cache has a value for a particular key
+     *
+     * @api
+     *
+     * @param string $key the key of the cache entry
+     * @return boolean true if the cache has a value for this key, otherwise false
+     */
+    public function has($key)
+    {
+        return \apc_exists($key);
+    }
+
+    /**
      * Returns the value of a cache entry from its key
      *
      * @api

--- a/src/Prismic/Cache/NoCache.php
+++ b/src/Prismic/Cache/NoCache.php
@@ -20,6 +20,19 @@ namespace Prismic\Cache;
 class NoCache implements CacheInterface
 {
     /**
+     * Tests whether the cache has a value for a particular key
+     *
+     * @api
+     *
+     * @param string $key the key of the cache entry
+     * @return boolean true if the cache has a value for this key, otherwise false
+     */
+    public function has($key)
+    {
+        return false;
+    }
+
+    /**
      * Returns the value of a cache entry from its key
      *
      * @api

--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -312,7 +312,7 @@ class SearchForm
      */
     public function isCached()
     {
-        return $this->api->getCache()->get($this->cache_key()) !== null;
+        return $this->api->getCache()->has($this->cache_key());
     }
 
     /**

--- a/tests/Prismic/CacheTest.php
+++ b/tests/Prismic/CacheTest.php
@@ -25,15 +25,24 @@ class CacheTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->cache->get('key'));
     }
 
-    public function testSetValueClear()
+    public function testSetValueClearHas()
     {
         $this->cache->set('key', 'value');
+        $this->assertTrue($this->cache->has('key'));
+        $this->assertFalse($this->cache->has('key1'));
+        $this->assertFalse($this->cache->has('key2'));
         $this->cache->set('key1', 'value1');
         $this->cache->set('key2', 'value2');
+        $this->assertTrue($this->cache->has('key'));
+        $this->assertTrue($this->cache->has('key1'));
+        $this->assertTrue($this->cache->has('key2'));
         $this->assertEquals($this->cache->get('key'), 'value');
         $this->assertEquals($this->cache->get('key1'), 'value1');
         $this->assertEquals($this->cache->get('key2'), 'value2');
         $this->cache->clear();
+        $this->assertFalse($this->cache->has('key'));
+        $this->assertFalse($this->cache->has('key1'));
+        $this->assertFalse($this->cache->has('key2'));
         $this->assertNull($this->cache->get('key'));
         $this->assertNull($this->cache->get('key1'));
         $this->assertNull($this->cache->get('key2'));


### PR DESCRIPTION
Rationale: though to my knowledge Prismic never caches a null value,
it is possible for caches to store null and for that to be different
from the key not existing in cache. Adding a has method to the
CacheInterface allows developers to provide a more reliable way to
tell these apart, if available for the cache backend. This also leads
to a fuller cache interface. In many cases (especially if the value is
large, as some will be in Prismic) checking if a key exists in cache
can be much faster than retrieving the value and checking against
null.