### PR TITLE
Don't hash cache keys

### DIFF
--- a/src/Prismic/Cache/CacheInterface.php
+++ b/src/Prismic/Cache/CacheInterface.php
@@ -13,9 +13,17 @@ namespace Prismic\Cache;
 /**
  * This is the interface you're supposed to implement if you want to
  * use your own caching strategy with the kit.
+ *
  * The way it works is pretty simple: implement the methods with your
  * implementation, and pass an instance of your class as the $cache parameter
  * in your Prismic\Api::get call.
+ *
+ * When writing your implementation be sure to check if your cache backend has a
+ * maximum key length. If so you will need to perform an operation on the key
+ * passed to the interface methods to limit the length, such as hashing it,
+ * since there is no guarantee that the passed keys will be any particular
+ * length.
+ *
  * Two implementations are included in the PHP kit out-of-the-box:
  * DefaultCache (which works with APC) and NoCache (which doesn't cache).
  *

--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -286,24 +286,13 @@ class SearchForm
     }
 
     /**
-     * Turn a URL into a cache key
-     *
-     * @param string $url the URL to convert
-     * @return string the cache key
-     */
-    private static function url_to_cache_key($url)
-    {
-        return md5($url);
-    }
-
-    /**
      * Get the cache key for this form
      *
      * @return string the cache key
      */
     private function cache_key()
     {
-        return self::url_to_cache_key($this->url());
+        return $this->url();
     }
 
     /**
@@ -331,7 +320,7 @@ class SearchForm
             $this->form->getAction()
         ) {
             $url = $this->url();
-            $cacheKey = self::url_to_cache_key($url);
+            $cacheKey = $this->cache_key();
 
             $response = $this->api->getCache()->get($cacheKey);
 

--- a/tests/Prismic/LesBonnesChosesTest.php
+++ b/tests/Prismic/LesBonnesChosesTest.php
@@ -116,7 +116,7 @@ class LesBonnesChosesTest extends \PHPUnit_Framework_TestCase
         $fakeResponse->next_page = NULL;
         $fakeResponse->prev_page = NULL;
 
-        \apc_store(md5('http://lesbonneschoses.cdn.prismic.io/api/documents/search?page=1&pageSize=20&ref=UlfoxUnM08QWYXdl'), $fakeResponse, 1000);
+        \apc_store('http://lesbonneschoses.cdn.prismic.io/api/documents/search?page=1&pageSize=20&ref=UlfoxUnM08QWYXdl', $fakeResponse, 1000);
 
         $results2 = $api->forms()->everything->ref($masterRef)->submit();
 


### PR DESCRIPTION
This reverts most of commit 9890bb7f08c573909d1c9d4d5e8dea512a5b677c,
and its author @gsteel will need to update his Memcached
CacheInterface implementation after this patch.

There is some discussion at
https://github.com/prismicio/php-kit/issues/83

Before this patch, most cache keys were being hashed before being sent
to the CacheInterface, to limit their length.

However, though some cache backends have low key length limits, many
(including APC, which Prismic supports, and Redis and more) do not.
For these, the hashing operation is not required. It is preferable
when administrating and debugging a cache for the keys not to be
hashed, since when hashed the keys are no longer sortable in an
appreciable way and there is no clue to what the corresponding cache
values might contain.

Notably, one item cached by Prismic (the API data) did not have its
key hashed first anyway.

This patch also adds some documentation to CacheInterface to advise
developers to check if the cache backend they are writing an
implementation for has such a limit, and provides a suggestion as to
what to do if so.