### PR TITLE
Date#asDateTime: force time to midnight

### DIFF
--- a/src/Prismic/Fragment/Date.php
+++ b/src/Prismic/Fragment/Date.php
@@ -66,7 +66,7 @@ class Date implements FragmentInterface
      */
     public function asDateTime()
     {
-        return DateTime::createFromFormat('Y-m-d', $this->value);
+        return DateTime::createFromFormat('Y-m-d', $this->value)->setTime(0, 0, 0);
     }
 
     /**


### PR DESCRIPTION
Without forcing time to midnight, date fragments (which don't provide
a time, only date) come back as DateTimes with the current time of
day.