### PR TITLE
Dispatch events before and after search form is submitted

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -14,6 +14,7 @@ use Ivory\HttpAdapter\Configuration;
 use Ivory\HttpAdapter\CurlHttpAdapter;
 use Ivory\HttpAdapter\Event\Subscriber\StatusCodeSubscriber;
 use Ivory\HttpAdapter\HttpAdapterInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use \Prismic\Cache\CacheInterface;
 use \Prismic\Cache\ApcCache;
 use \Prismic\Cache\NoCache;
@@ -50,6 +51,10 @@ class Api
      * @var HttpAdapterInterface
      */
     private $httpAdapter;
+    /**
+     * @var EventDispatcher
+     */
+    private $dispatcher;
 
     /**
      * Private constructor, not be used outside of this class.
@@ -65,6 +70,7 @@ class Api
         $this->accessToken = $accessToken;
         $this->httpAdapter = is_null($httpAdapter) ? self::defaultHttpAdapter() : $httpAdapter;
         $this->cache = is_null($cache) ? self::defaultCache() : $cache;
+        $this->dispatcher = new EventDispatcher();
     }
 
     /**
@@ -264,6 +270,17 @@ class Api
     public function getCache()
     {
         return $this->cache;
+    }
+
+    /**
+     * Accessing the event dispatcher
+     *
+     * @return EventDispatcher the event dispatcher
+     *
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
     }
 
     /**

--- a/src/Prismic/Event/PostSubmitEvent.php
+++ b/src/Prismic/Event/PostSubmitEvent.php
@@ -50,6 +50,16 @@ class PostSubmitEvent extends Event
     }
 
     /**
+     * Get the object representing the JSON response from Prismic
+     *
+     * @return stdClass JSON
+     */
+    public function getJson()
+    {
+        return $this->json;
+    }
+
+    /**
      * Was the response a cache hit?
      *
      * @return boolean true if the response came from the cache

--- a/src/Prismic/Event/PostSubmitEvent.php
+++ b/src/Prismic/Event/PostSubmitEvent.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Prismic\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Prismic\SearchForm;
+
+/**
+ * An event dispatched after a SearchForm object's submission receives a
+ * response.
+ */
+class PostSubmitEvent extends Event
+{
+
+    /**
+     * @var SearchForm
+     */
+    private $searchForm;
+    /**
+     * @var \stdClass
+     */
+    private $json;
+    /**
+     * @var boolean
+     */
+    private $cacheHit;
+
+    /**
+     * Make a new instance
+     *
+     * @param SearchForm $searchForm the associated search form
+     * @param \stdClass the JSON response from the API
+     * @param boolean $cacheHit true if the response came from the cache
+     */
+    public function __construct(SearchForm $searchForm, \stdClass $json, $cacheHit)
+    {
+        $this->searchForm = $searchForm;
+        $this->json = $json;
+        $this->cacheHit = $cacheHit;
+    }
+
+    /**
+     * Get the search form associated with this event
+     *
+     * @return SearchForm the search form
+     */
+    public function getSearchForm()
+    {
+        return $this->searchForm;
+    }
+
+    /**
+     * Was the response a cache hit?
+     *
+     * @return boolean true if the response came from the cache
+     */
+    public function wasCacheHit()
+    {
+        return $this->cacheHit;
+    }
+
+}

--- a/src/Prismic/Event/PreSubmitEvent.php
+++ b/src/Prismic/Event/PreSubmitEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Prismic\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Prismic\SearchForm;
+
+/**
+ * An event dispatched when a SearchForm object is about to be submitted.
+ */
+class PreSubmitEvent extends Event
+{
+
+    /**
+     * @var SearchForm
+     */
+    private $searchForm;
+
+    /**
+     * Make a new instance
+     *
+     * @param SearchForm $searchForm the associated search form
+     */
+    public function __construct(SearchForm $searchForm)
+    {
+        $this->searchForm = $searchForm;
+    }
+
+    /**
+     * Get the search form associated with this event
+     *
+     * @return SearchForm the search form
+     */
+    public function getSearchForm()
+    {
+        return $this->searchForm;
+    }
+
+}

--- a/src/Prismic/Events.php
+++ b/src/Prismic/Events.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Prismic;
+
+final class Events
+{
+
+    /**
+     * The prismic.pre_submit event is dispatched just before a search form is
+     * submitted.
+     *
+     * Event listeners receive a Prismic\Event\PreSubmitEvent instance.
+     *
+     * @var string
+     */
+    const PRE_SUBMIT = 'prismic.pre_submit';
+
+    /**
+     * The prismic.post_submit event is dispatched just after a search form
+     * submission's response is received.
+     *
+     * Event listeners receive a Prismic\Event\PostSubmitEvent instance.
+     *
+     * @var string
+     */
+    const POST_SUBMIT = 'prismic.post_submit';
+
+}

--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -10,6 +10,9 @@
 
 namespace Prismic;
 
+use Prismic\Event\PreSubmitEvent;
+use Prismic\Event\PostSubmitEvent;
+
 /**
  * Embodies an API call we are in the process of building. This gets started with Prismic\Api.form,
  * then you can chain instance method calls to build your query, and the query gets launched with
@@ -315,15 +318,23 @@ class SearchForm
             $this->form->getEnctype() == 'application/x-www-form-urlencoded' &&
             $this->form->getAction()
         ) {
+            $dispatcher = $this->api->getDispatcher();
+            $preSubmitEvent = new PreSubmitEvent($this);
+            $dispatcher->dispatch(Events::PRE_SUBMIT, $preSubmitEvent);
+
             $url = $this->url();
             $cacheKey = $this->url();
 
             $response = $this->api->getCache()->get($cacheKey);
 
             if ($response) {
+                $postSubmitEvent = new PostSubmitEvent($this, $response, true);
+                $dispatcher->dispatch(Events::POST_SUBMIT, $postSubmitEvent);
+
                 return $response;
             } else {
                 $response = $this->api->getHttpAdapter()->get($url);
+
                 $cacheControl = $response->getHeader('Cache-Control');
                 $cacheDuration = null;
                 if (preg_match('/^max-age\s*=\s*(\d+)$/', $cacheControl, $groups) == 1) {
@@ -333,6 +344,10 @@ class SearchForm
                 if (!isset($json)) {
                     throw new \RuntimeException("Unable to decode json response");
                 }
+
+                $postSubmitEvent = new PostSubmitEvent($this, $json, false);
+                $dispatcher->dispatch(Events::POST_SUBMIT, $postSubmitEvent);
+
                 if ($cacheDuration !== null) {
                     $expiration = $cacheDuration;
                     $this->api->getCache()->set($cacheKey, $json, $expiration);

--- a/tests/Prismic/EventsTest.php
+++ b/tests/Prismic/EventsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Prismic\Test;
+
+use Prismic\Cache\ApcCache;
+use Prismic\Document;
+use Prismic\Api;
+use Prismic\Events;
+use Prismic\Event\PreSubmitEvent;
+use Prismic\Event\PostSubmitEvent;
+use Symfony\Component\EventDispatcher\Event;
+
+class EventsTest extends \PHPUnit_Framework_TestCase
+{
+    private static $testRepository = 'http://micro.prismic.io/api';
+
+    protected $document;
+    protected $linkResolver;
+    protected $micro_api;
+
+    protected function setUp()
+    {
+        $cache = new ApcCache();
+        $cache->clear();
+        $search = json_decode(file_get_contents(__DIR__.'/../fixtures/search.json'));
+        $this->document = Document::parse($search[0]);
+        $this->micro_api = Api::get(self::$testRepository, null, null, $cache);
+        $this->linkResolver = new FakeLinkResolver();
+    }
+
+    public function testEvents()
+    {
+        $masterRef = $this->micro_api->master()->getRef();
+        $searchForm = $this->micro_api->forms()->everything->ref($masterRef)->query('[[:d = at(document.id, "U9pjvjQAADAAehbf")]]');
+
+        $dispatcher = $this->micro_api->getDispatcher();
+
+        $testCase = $this;
+
+        $preRunCount = 0;
+        $postRunCount = 0;
+
+        $dispatcher->addListener(Events::PRE_SUBMIT, function(Event $event) use($testCase, &$preRunCount, $searchForm) {
+            $preRunCount++;
+            $testCase->assertInstanceOf('Prismic\Event\PreSubmitEvent', $event);
+            $testCase->assertSame($event->getSearchForm(), $searchForm);
+        });
+
+        $dispatcher->addListener(Events::POST_SUBMIT, function(Event $event) use($testCase, &$postRunCount, $searchForm) {
+            $postRunCount++;
+            $testCase->assertInstanceOf('Prismic\Event\PostSubmitEvent', $event);
+            $testCase->assertSame($event->getSearchForm(), $searchForm);
+            $testCase->assertInternalType('boolean', $event->wasCacheHit());
+        });
+
+        $searchForm->submit()->getResults();
+
+        $this->assertEquals($preRunCount, 1);
+        $this->assertEquals($postRunCount, 1);
+    }
+
+}


### PR DESCRIPTION
A new method `Api#getDispatcher` is added, which gets an
`EventDispatcher` instance. Events can be subscribed to/listened for
via this object.

The events `prismic.pre_submit` and `prismic.post_submit` are fired
just before a search form is submitted and just after the response is
received and parsed as JSON, respectively. Both events allow the
`SearchForm` object to be retrieved, inspected and operated on, and
the `prismic.post_submit` event additionally provides the JSON
response object and a boolean denoting whether the response came from
the cache or not.

Using these events, a developer can for instance alter the form before
it is sent, or log queries and how long they take.
