### PR TITLE
Pass linkResolver to htmlSerializer

### DIFF
--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -202,7 +202,7 @@ class StructuredText implements FragmentInterface
      *
      * @param \Prismic\LinkResolver $linkResolver the link resolver
      *
-     * @param lambda $htmlSerializer an optional function to generate custom HTML code
+     * @param callable $htmlSerializer an optional function to generate custom HTML code
      * @return string the HTML version of the StructuredText fragment
      */
     public function asHtml($linkResolver = null, $htmlSerializer = null)
@@ -263,7 +263,7 @@ class StructuredText implements FragmentInterface
      * @param \Prismic\Fragment\Block\BlockInterface $block a given block
      * @param \Prismic\LinkResolver $linkResolver the link resolver
      *
-     * @param lambda $htmlSerializer
+     * @param callable $htmlSerializer
      * @return string the HTML version of the block
      */
     public static function asHtmlBlock($block, $linkResolver = null, $htmlSerializer = null)
@@ -373,7 +373,7 @@ class StructuredText implements FragmentInterface
      * @param BlockInterface|SpanInterface $element block or span to serialize
      * @param string $content inner html of the element
      * @param LinkResolver $linkResolver
-     * @param HtmlSerializer $htmlSerializer
+     * @param callable $htmlSerializer
      */
     private static function serialize($element, $content, $linkResolver, $htmlSerializer) {
         if (!is_null($htmlSerializer)) {

--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -377,7 +377,7 @@ class StructuredText implements FragmentInterface
      */
     private static function serialize($element, $content, $linkResolver, $htmlSerializer) {
         if (!is_null($htmlSerializer)) {
-            $custom = $htmlSerializer($element, $content);
+            $custom = $htmlSerializer($element, $content, $linkResolver);
             if (!is_null($custom)) {
                 return $custom;
             }

--- a/tests/Prismic/DocTest.php
+++ b/tests/Prismic/DocTest.php
@@ -154,9 +154,9 @@ class DocTest extends \PHPUnit_Framework_TestCase
         // The resolver is defined here:
         // https://github.com/prismicio/php-kit/blob/master/tests/Prismic/FakeLinkResolver.php
         $resolver = new FakeLinkResolver();
-        $htmlSerializer = function($element, $content) use ($resolver) {
+        $htmlSerializer = function($element, $content, $linkResolver) {
             if ($element instanceof ImageBlock) {
-                return nl2br($element->getView()->asHtml($resolver));
+                return nl2br($element->getView()->asHtml($linkResolver));
             }
             return null;
         };

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -171,7 +171,7 @@ class StructuredTextTest Extends \PHPUnit_Framework_TestCase
     public function testStructuredTextCustomHtmlSerializer()
     {
         $linkResolver = new FakeLinkResolver();
-        $htmlSerializer = function($element, $content) use ($linkResolver) {
+        $htmlSerializer = function($element, $content, $linkResolver) {
             if ($element instanceof ImageBlock) {
                 return nl2br($element->getView()->asHtml($linkResolver));
             }


### PR DESCRIPTION
This makes for more flexibility and reusability of htmlSerializers

See #106, part of which was this change.
