### PR TITLE
Fix experiment cookie parsing

### DIFF
--- a/src/Prismic/Experiments.php
+++ b/src/Prismic/Experiments.php
@@ -33,7 +33,7 @@ class Experiments {
     public function refFromCookie($cookie)
     {
         if ($cookie == null) return null;
-        $splitted = preg_split("/%20/", trim($cookie));
+        $splitted = explode(' ', trim($cookie));
 
         if (count($splitted) >= 2)
         {


### PR DESCRIPTION
When getting a cookie via PHP's $_COOKIE superglobal, the value is
already unescaped. Because of this, there was no instance of %20 to
split on.

(Also changed preg_replace for explode, since there's no need for a slow
regex here.)