### PR TITLE
Update egeloen/http-adapter to 0.8.0. Updated code for API changes in egeloen/http-adapter. All tests pass.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "egeloen/http-adapter": "0.6.0",
+        "egeloen/http-adapter": "~0.8.0",
         "symfony/event-dispatcher": "~2.0"
     },
     "require-dev": {

--- a/src/Prismic/SearchForm.php
+++ b/src/Prismic/SearchForm.php
@@ -318,7 +318,7 @@ class SearchForm
                 return $response;
             } else {
                 $response = $this->api->getHttpAdapter()->get($url);
-                $cacheControl = $response->getHeader('Cache-Control');
+                $cacheControl = $response->getHeader('Cache-Control')[0];
                 $cacheDuration = null;
                 if (preg_match('/^max-age\s*=\s*(\d+)$/', $cacheControl, $groups) == 1) {
                     $cacheDuration = (int) $groups[1];


### PR DESCRIPTION
Related to issue #111.

I've got a Symfony 2.7 project and I was unable to install the php-kit due to a conflict with Guzzle. egeloen/http-adapter 0.8.0 doesn't conflict, but the API is slightly different and then caused the PHP kit to stop working.

This pull request updates the library to 0.8.0 and fixes the internal parts of the Prismic API class that stopped working as a result. From what I can see it shouldn't affect code using the Prismic API classes, but those who've worked on this code for a while might be able to shed more light on this.

All the unit tests pass with my changes.