### PR TITLE
update egeloen/http-adapter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "egeloen/http-adapter": "0.6.0",
+        "egeloen/http-adapter": "^0.6.0",
         "symfony/event-dispatcher": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
egeloen/http-adapter on version 0.6.* uses guzzle on version <6. But guzzle is now on version 6, and many other packages require guzzle 6.