### PR TITLE
Return $defaultUrl in Api::previewSession()

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -238,7 +238,9 @@ class Api
                 ->submit()
                 ->getResults();
             if (count($documents) > 0) {
-                return $linkResolver->resolveDocument($documents[0]);
+                if ($url = $linkResolver->resolveDocument($documents[0])) {
+                    return $url;
+                }
             }
         }
         return $defaultUrl;


### PR DESCRIPTION
If the link resolver is unable to resolve the URL for the preview document and returns null, return the given default URL as opposed to the null received from the link resolver.

i.e - at the moment, I redirect to whatever URL Api::previewSession returns. If I get a null, my framework complains about a header with no value. I think this method should always return a string as the docs state, so whilst I could easily check the return value for this, I shouldn't have to…