### PR TITLE
Add missing helpers and improve composer.json file (~ → ^)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "symfony/event-dispatcher": "~3.1.4",
+        "symfony/event-dispatcher": "^3.1.4",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "dev-master",
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "^4.1"
     },
     "extra": {
         "branch-alias": {

--- a/src/Prismic/Predicates.php
+++ b/src/Prismic/Predicates.php
@@ -30,6 +30,16 @@ class Predicates {
 
     /**
      * @param string $fragment
+     * @param string $value
+     *
+     * @return SimplePredicate
+     */
+    public static function not($fragment, $value) {
+        return new SimplePredicate("not", $fragment, array($value));
+    }
+
+    /**
+     * @param string $fragment
      * @param string $values
      *
      * @return SimplePredicate

--- a/tests/Prismic/PredicatesTest.php
+++ b/tests/Prismic/PredicatesTest.php
@@ -14,6 +14,12 @@ class PredicatesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('[:d = at(document.type, "blog-post")]', $predicate->q());
     }
 
+    public function testNotPredicate()
+    {
+        $predicate = Predicates::not("document.type", "blog-post");
+        $this->assertEquals('[:d = not(document.type, "blog-post")]', $predicate->q());
+    }
+
 
     public function testAnyPredicate()
     {

--- a/tests/Prismic/PublicationDatesTest.php
+++ b/tests/Prismic/PublicationDatesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Prismic\Test;
+
+use Prismic\Document;
+
+class PublicationDateTest extends \PHPUnit_Framework_TestCase
+{
+    protected $documents;
+
+    protected function setUp()
+    {
+        $results = json_decode(file_get_contents(__DIR__.'/../fixtures/publication_dates.json'));
+        $this->documents = array();
+        foreach ($results as $idx => $result) {
+            $this->documents[$idx] = Document::parse($result);
+        }
+    }
+
+    public function testGetFirstPublicationDate()
+    {
+        $date = $this->documents[0]->getFirstPublicationDate();
+        $this->assertEquals(1477463000, $date->getTimestamp());
+    }
+
+    public function testGetLastPublicationDate()
+    {
+        $date = $this->documents[0]->getLastPublicationDate();
+        $this->assertEquals(1482733400, $date->getTimestamp());
+    }
+
+    public function testEmptyGetFirstPublicationDate()
+    {
+        $date = $this->documents[2]->getFirstPublicationDate();
+        $this->assertEquals(null, $date);
+    }
+
+    public function testEmptyGetLastPublicationDate()
+    {
+        $date = $this->documents[2]->getLastPublicationDate();
+        $this->assertEquals(null, $date);
+    }
+
+    public function testMixedGetFirstPublicationDate()
+    {
+        $date = $this->documents[1]->getFirstPublicationDate();
+        $this->assertEquals(null, $date);
+    }
+
+    public function testMixedGetLastPublicationDate()
+    {
+        $date = $this->documents[1]->getLastPublicationDate();
+        $this->assertEquals(1482733400, $date->getTimestamp());
+    }
+
+}

--- a/tests/fixtures/publication_dates.json
+++ b/tests/fixtures/publication_dates.json
@@ -1,0 +1,65 @@
+[
+    {
+        "id": "WBBMECcAABESvVA1",
+        "uid": "doc1",
+        "type": "doc",
+        "href": "https://testrepo.prismic.io/api/documents/search?ref=WF6bvCYAAK08dXme&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WBBMECcAABESvVA1%22%29+%5D%5D",
+        "tags": [],
+        "first_publication_date": "2016-10-26T06:23:20+0000",
+        "last_publication_date": "2016-12-26T06:23:20+0000",
+        "slugs": [
+            "doc1"
+        ],
+        "linked_documents": [],
+        "data": {
+            "post": {
+                "title": {
+                    "type": "Text",
+                    "value": "Doc1"
+                }
+            }
+        }
+    },
+    {
+        "id": "WBBMECcAABESvVA2",
+        "uid": "doc2",
+        "type": "doc",
+        "href": "https://testrepo.prismic.io/api/documents/search?ref=WF6bvCYAAK08dXme&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WBBMECcAABESvVA2%22%29+%5D%5D",
+        "tags": [],
+        "first_publication_date": null,
+        "last_publication_date": "2016-12-26T06:23:20+0000",
+        "slugs": [
+            "doc2"
+        ],
+        "linked_documents": [],
+        "data": {
+            "post": {
+                "title": {
+                    "type": "Text",
+                    "value": "Doc2"
+                }
+            }
+        }
+    },
+    {
+        "id": "WBBMECcAABESvVA3",
+        "uid": "doc3",
+        "type": "doc",
+        "href": "https://testrepo.prismic.io/api/documents/search?ref=WF6bvCYAAK08dXme&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WBBMECcAABESvVA3%22%29+%5D%5D",
+        "tags": [],
+        "first_publication_date": null,
+        "last_publication_date": null,
+        "slugs": [
+            "doc3"
+        ],
+        "linked_documents": [],
+        "data": {
+            "post": {
+                "title": {
+                    "type": "Text",
+                    "value": "Doc3"
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
- Add `not` predicate
- Add tests on publication dates
- Require `symfony/event-dispatcher` and `phpunit` using caret instead of tilde since this form will accept any [semantic versioning](http://semver.org/)'s non-breaking version. (should resolves #128)