### PR TITLE
Experiment ref from cookie

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -421,7 +421,17 @@ class Api
         ];
         foreach ($cookieNames as $cookie) {
             if (isset($_COOKIE[$cookie])) {
-                return $_COOKIE[$cookie];
+                // For Preview Cookies, the ref is the cookie value
+                $ref = $_COOKIE[$cookie];
+                if(strpos($cookie, 'experiment') !== false) {
+                    // For experiment cookies, the ref must be looked up by the Google ID
+                    $experiments = $this->getExperiments();
+                    $result = $experiments->refFromCookie($_COOKIE[$cookie]);
+                    if(null !== $result) {
+                        $ref = $result;
+                    }
+                }
+                return $ref;
             }
         }
         return (string) $this->master()->getRef();

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -9,11 +9,13 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
     private $api;
 
+    private $experiments;
+
     public function setUp()
     {
         $this->api = $this->getMockBuilder(Prismic\Api::class)
             ->disableOriginalConstructor()
-            ->setMethods(['master'])
+            ->setMethods(['master', 'getExperiments'])
             ->getMock();
 
         $master = new Prismic\Ref('Master', 'Master-Ref-String', 'Master', true, null);
@@ -21,6 +23,19 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->api
              ->method('master')
              ->willReturn($master);
+
+        $this->experiments = $this->getMockBuilder(Prismic\Experiments::class)
+             ->disableOriginalConstructor()
+             ->setMethods(['refFromCookie'])
+             ->getMock();
+
+        $this->experiments
+             ->method('refFromCookie')
+             ->willReturn('experiment');
+
+        $this->api
+             ->method('getExperiments')
+             ->willReturn($this->experiments);
     }
 
     public function testRef()


### PR DESCRIPTION
Currently, Api::ref() will return the google experiment id as the ref which results in a 404 from the Prismic API. The ref needs to be retrieved from the running experiments by finding the experiment by it's Google ID and corresponding ref.