### PR TITLE
Unserialize cached api data only if the cache returns a string.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpdoc.dist.xml
 .idea
 node_modules/
 phpunit.xml
+/build/

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -302,10 +302,17 @@ class Api
      */
     public static function get($action, $accessToken = null, $httpClient = null, CacheInterface $cache = null, $apiCacheTTL = 5)
     {
-        $cache = is_null($cache) ? self::defaultCache() : $cache;
+        $cache    = is_null($cache) ? self::defaultCache() : $cache;
         $cacheKey = $action . (is_null($accessToken) ? "" : ("#" . $accessToken));
-        $apiData = $cache->get($cacheKey);
-        $api = $apiData ? new Api(unserialize($apiData), $accessToken, $httpClient, $cache) : null;
+
+        $apiData  = $cache->get($cacheKey);
+        $apiData  = is_string($apiData)
+                  ? unserialize($apiData)
+                  : $apiData;
+
+        $api      = $apiData
+                  ? new Api($apiData, $accessToken, $httpClient, $cache)
+                  : null;
         if ($api) {
             return $api;
         } else {

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -71,15 +71,15 @@ class Api
      * Private constructor, not be used outside of this class.
      */
     private function __construct(
-      $data /**< string */,
-      $accessToken = null /**< optional access token, if the API is private */,
-      Client $httpClient = null,
-      CacheInterface $cache = null)
-    {
+        ApiData $data,
+        $accessToken = null /**< optional access token, if the API is private */,
+        Client $httpClient = null,
+        CacheInterface $cache = null
+    ) {
         $this->data        = $data;
         $this->accessToken = $accessToken;
-        $this->httpClient = is_null($httpClient) ? new Client() : $httpClient;
-        $this->cache = is_null($cache) ? self::defaultCache() : $cache;
+        $this->httpClient  = is_null($httpClient) ? new Client() : $httpClient;
+        $this->cache       = is_null($cache) ? self::defaultCache() : $cache;
     }
 
     /**
@@ -310,7 +310,7 @@ class Api
                   ? unserialize($apiData)
                   : $apiData;
 
-        $api      = $apiData
+        $api      = $apiData instanceof ApiData
                   ? new Api($apiData, $accessToken, $httpClient, $cache)
                   : null;
         if ($api) {


### PR DESCRIPTION
This seems like a safe thing to do. If you’re using a cache implementation
that automatically unserializes data as it’s retrieved from the cache Api::get()
will be trying to unserialize an object. This change allows for a wider range of
cache implementations without breaking existing behaviour.