### PR TITLE
Fixes an issue where a stale experiment cookie causes an Api 404

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -203,7 +203,7 @@ class Api
     }
 
     /**
-     * @return Experiments
+     * @return \Prismic\Experiments
      */
     public function getExperiments()
     {
@@ -405,6 +405,47 @@ class Api
     }
 
     /**
+     * If a preview cookie is set, return the ref stored in that cookie
+     *
+     * @return string|null
+     */
+    private function getPreviewRef()
+    {
+        $cookieNames = [
+            str_replace(['.',' '], '_', self::PREVIEW_COOKIE),
+            self::PREVIEW_COOKIE,
+        ];
+        foreach ($cookieNames as $cookieName) {
+            if (isset($_COOKIE[$cookieName])) {
+                return $_COOKIE[$cookieName];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * If an experiment cookie is set, return the ref as determined by \Prismic\Experiments::refFromCookie
+     *
+     * @return string|null
+     */
+    private function getExperimentRef()
+    {
+        $cookieNames = [
+            str_replace(['.',' '], '_', self::EXPERIMENTS_COOKIE),
+            self::EXPERIMENTS_COOKIE,
+        ];
+        foreach ($cookieNames as $cookieName) {
+            if (isset($_COOKIE[$cookieName])) {
+                $experiments = $this->getExperiments();
+                return $experiments->refFromCookie($_COOKIE[$cookieName]);
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Return the ref currently in use
      *
      * In order of preference, returns the preview cookie, the experiments cookie or the master ref otherwise
@@ -413,26 +454,13 @@ class Api
      */
     public function ref()
     {
-        $cookieNames = [
-            str_replace(['.',' '], '_', self::PREVIEW_COOKIE),
-            self::PREVIEW_COOKIE,
-            str_replace(['.',' '], '_', self::EXPERIMENTS_COOKIE),
-            self::EXPERIMENTS_COOKIE,
-        ];
-        foreach ($cookieNames as $cookie) {
-            if (isset($_COOKIE[$cookie])) {
-                // For Preview Cookies, the ref is the cookie value
-                $ref = $_COOKIE[$cookie];
-                if(strpos($cookie, 'experiment') !== false) {
-                    // For experiment cookies, the ref must be looked up by the Google ID
-                    $experiments = $this->getExperiments();
-                    $result = $experiments->refFromCookie($_COOKIE[$cookie]);
-                    if(null !== $result) {
-                        $ref = $result;
-                    }
-                }
-                return $ref;
-            }
+        $preview = $this->getPreviewRef();
+        if ($preview) {
+            return $preview;
+        }
+        $experiment = $this->getExperimentRef();
+        if ($experiment) {
+            return $experiment;
         }
         return (string) $this->master()->getRef();
     }

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -29,10 +29,6 @@ class ApiTest extends \PHPUnit_Framework_TestCase
              ->setMethods(['refFromCookie'])
              ->getMock();
 
-        $this->experiments
-             ->method('refFromCookie')
-             ->willReturn('experiment');
-
         $this->api
              ->method('getExperiments')
              ->willReturn($this->experiments);
@@ -82,8 +78,21 @@ class ApiTest extends \PHPUnit_Framework_TestCase
      */
     public function testCorrectRefIsReturned($cookie, $expect)
     {
+        // Make sure that Prismic\Experiments::refFromCookie returns a 'valid' ref
+        $this->experiments->method('refFromCookie')->willReturn('experiment');
         $_COOKIE = $cookie;
         $this->assertSame($expect, $this->api->ref());
     }
+
+    public function testRefDoesNotReturnStaleExperimentRef()
+    {
+        // Make sure that Prismic\Experiments::refFromCookie returns null, i.e. no experiment running
+        $this->experiments->method('refFromCookie')->willReturn(null);
+        $_COOKIE = [
+            'io.prismic.experiment' => 'Stale Experiment Cookie Value',
+        ];
+        $this->assertSame('Master-Ref-String', $this->api->ref());
+    }
+
 
 }


### PR DESCRIPTION
The experiment cookie value was previously being returned unmodified if found, therefore, users with an experiment cookie for a completed experiment would cause the library to request a ref that did not exist in the API. That was a bad thing.