### PR TITLE
Add Slice Interface

### DIFF
--- a/src/Prismic/Fragment/CompositeSlice.php
+++ b/src/Prismic/Fragment/CompositeSlice.php
@@ -2,7 +2,7 @@
 
 namespace Prismic\Fragment;
 
-class CompositeSlice implements FragmentInterface
+class CompositeSlice implements SliceInterface
 {
 
     /**
@@ -38,6 +38,11 @@ class CompositeSlice implements FragmentInterface
         $this->nonRepeat = $nonRepeat;
     }
 
+    /**
+     * Return text representation of slice
+     *
+     * @return string
+     */
     public function asText()
     {
         $string = '';
@@ -53,6 +58,11 @@ class CompositeSlice implements FragmentInterface
         return $string;
     }
 
+    /**
+     * Return HTML representation of slice
+     *
+     * @return string
+     */
     public function asHtml($linkResolver = null)
     {
         $classes = array('slice');

--- a/src/Prismic/Fragment/CompositeSlice.php
+++ b/src/Prismic/Fragment/CompositeSlice.php
@@ -126,4 +126,14 @@ class CompositeSlice implements SliceInterface
         return $this->repeat;
     }
 
+    /**
+     * Whether the slice is composite or not
+     *
+     * @return bool
+     */
+    public function isComposite()
+    {
+        return true;
+    }
+
 }

--- a/src/Prismic/Fragment/Slice.php
+++ b/src/Prismic/Fragment/Slice.php
@@ -13,10 +13,24 @@ namespace Prismic\Fragment;
 /**
  * This class embodies a Slice fragment.
  */
-class Slice implements FragmentInterface
+class Slice implements SliceInterface
 {
+
     /**
-     * @var fragment the inner value of the fragment
+     * Slice Type as defined in Json
+     * @var string
+     */
+    private $sliceType;
+
+    /**
+     * Slice Label
+     * @var string|null
+     */
+    private $label;
+
+    /**
+     * the inner value of the fragment
+     * @var FragmentInterface
      */
     private $value;
 
@@ -24,10 +38,10 @@ class Slice implements FragmentInterface
      * Constructs a Slice object.
      *
      * @param string            $sliceType   the type of the slice as describe in the document mask
-     * @param string            $label  the optional label (may be null)
-     * @param Prismic\Fragment  $value       the inner fragment
+     * @param string|null       $label  the optional label (may be null)
+     * @param FragmentInterface $value       the inner fragment
      */
-    public function __construct($sliceType, $label, $value)
+    public function __construct($sliceType, $label, FragmentInterface $value)
     {
         $this->sliceType = $sliceType;
         $this->label = $label;
@@ -37,7 +51,7 @@ class Slice implements FragmentInterface
     /**
      * Builds a HTML version of the Text fragment.
      *
-     * 
+     *
      *
      * @param \Prismic\LinkResolver $linkResolver the link resolver
      *
@@ -55,7 +69,7 @@ class Slice implements FragmentInterface
     /**
      * Builds a text version of the Slice fragment.
      *
-     * 
+     *
      *
      * @return string the text version of the Text fragment
      */
@@ -67,7 +81,7 @@ class Slice implements FragmentInterface
     /**
      * Returns the slice type as declared in the Document Mask.
      *
-     * 
+     *
      *
      * @return  fragment the inner value of the fragment
      */
@@ -79,7 +93,7 @@ class Slice implements FragmentInterface
     /**
      * Returns the slice label as declared in the Document Mask.
      *
-     * 
+     *
      *
      * @return  fragment the inner value of the fragment
      */
@@ -91,9 +105,9 @@ class Slice implements FragmentInterface
     /**
      * Returns the inner value of the fragment.
      *
-     * 
      *
-     * @return  fragment the inner value of the fragment
+     *
+     * @return FragmentInterface the inner value of the fragment
      */
     public function getValue()
     {

--- a/src/Prismic/Fragment/Slice.php
+++ b/src/Prismic/Fragment/Slice.php
@@ -113,4 +113,14 @@ class Slice implements SliceInterface
     {
         return $this->value;
     }
+
+    /**
+     * Whether the slice is composite or not
+     *
+     * @return bool
+     */
+    public function isComposite()
+    {
+        return false;
+    }
 }

--- a/src/Prismic/Fragment/SliceInterface.php
+++ b/src/Prismic/Fragment/SliceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Prismic\Fragment;
+
+interface SliceInterface extends FragmentInterface
+{
+
+    /**
+     * Returns the slice type as declared in the Document Mask.
+     *
+     * @return string
+     */
+    public function getSliceType();
+
+    /**
+     * Returns the slice label as declared in the Document Mask.
+     *
+     * @return string|null
+     */
+    public function getLabel();
+
+}

--- a/src/Prismic/Fragment/SliceInterface.php
+++ b/src/Prismic/Fragment/SliceInterface.php
@@ -19,4 +19,11 @@ interface SliceInterface extends FragmentInterface
      */
     public function getLabel();
 
+    /**
+     * Whether the slice is composite or not
+     *
+     * @return bool
+     */
+    public function isComposite();
+
 }

--- a/tests/Prismic/SliceTest.php
+++ b/tests/Prismic/SliceTest.php
@@ -49,6 +49,7 @@ class SliceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Group::class, $slice->getItems());
         $this->assertInternalType('string', $slice->asText());
         $this->assertInternalType('string', $slice->asHtml());
+        $this->assertInternalType('bool', $slice->isComposite());
     }
 
     public function textContentValueProvider()


### PR DESCRIPTION
Add SliceInterface to represent common traits of normal slices and composite slices.

Also added some missing properties to the Slice class declaration and type hinted FragmentInterface in the constructor.