### PR TITLE
Add support for target blank

### DIFF
--- a/src/Prismic/Document.php
+++ b/src/Prismic/Document.php
@@ -265,7 +265,7 @@ class Document extends WithFragments
      */
     public function asDocumentLink()
     {
-        return new DocumentLink($this->id, $this->uid, $this->type, $this->tags, $this->getSlug(), $this->lang, $this->getFragments(), false);
+        return new DocumentLink($this->id, $this->uid, $this->type, $this->tags, $this->getSlug(), $this->lang, $this->getFragments(), false, null);
     }
 
     /**

--- a/src/Prismic/Fragment/ImageView.php
+++ b/src/Prismic/Fragment/ImageView.php
@@ -92,7 +92,16 @@ class ImageView
 
         if ($this->getLink() && ($url = $this->getLink()->getUrl($linkResolver)) !== null) {
             $a = $doc->createElement('a');
-            $a->setAttribute('href', $url);
+            $attributes = array( 'href' => $url );
+            if ($this->getLink()->getTarget()) {
+                $attributes = array_merge(array(
+                    'target' => $this->getLink()->getTarget(),
+                    'rel' => 'noopener',
+                ), $attributes);
+            }
+            foreach ($attributes as $attr => $value) {
+                $a->setAttribute($attr, $value);
+            };
             $a->appendChild($img);
             $doc->appendChild($a);
         } else {

--- a/src/Prismic/Fragment/Link/DocumentLink.php
+++ b/src/Prismic/Fragment/Link/DocumentLink.php
@@ -48,6 +48,10 @@ class DocumentLink extends WithFragments implements LinkInterface
      * @var boolean returns true if the link is towards a document that is not live, for instance
      */
     private $isBroken;
+    /**
+     * @var string the target of the link
+     */
+    private $target;
 
     /**
      * Constructs a document link.
@@ -60,8 +64,9 @@ class DocumentLink extends WithFragments implements LinkInterface
      * @param string  $lang      the language code of the document
      * @param array   $fragments the additional fragment data
      * @param boolean $isBroken  returns true if the link is towards a document that is not live, for instance
+     * @param string $target     the target of the link
      */
-    public function __construct($id, $uid, $type, $tags, $slug, $lang, array $fragments, $isBroken)
+    public function __construct($id, $uid, $type, $tags, $slug, $lang, array $fragments, $isBroken, $target = null)
     {
         parent::__construct($fragments);
         $this->id = $id;
@@ -71,6 +76,7 @@ class DocumentLink extends WithFragments implements LinkInterface
         $this->slug = $slug;
         $this->lang = $lang;
         $this->isBroken = $isBroken;
+        $this->target = $target;
     }
 
     /**
@@ -103,6 +109,7 @@ class DocumentLink extends WithFragments implements LinkInterface
         $uid = isset($json->document->uid) ? $json->document->uid : null;
         $lang = isset($json->document->lang) ? $json->document->lang : null;
         $fragments = isset($json->document->data) ? WithFragments::parseFragments($json->document->data) : array();
+        $target = property_exists($json, "target") ? $json->target : null;
         return new DocumentLink(
             $json->document->id,
             $uid,
@@ -111,7 +118,8 @@ class DocumentLink extends WithFragments implements LinkInterface
             $json->document->slug,
             $lang,
             $fragments,
-            $json->isBroken
+            $json->isBroken,
+            $target
         );
     }
 
@@ -214,6 +222,17 @@ class DocumentLink extends WithFragments implements LinkInterface
     public function getLang()
     {
         return $this->lang;
+    }
+
+    /**
+     * Returns the target of the link
+     *
+     *
+     * @return string the target of the link
+     */
+    public function getTarget()
+    {
+        return $this->target;
     }
 
     /**

--- a/src/Prismic/Fragment/Link/FileLink.php
+++ b/src/Prismic/Fragment/Link/FileLink.php
@@ -35,6 +35,10 @@ class FileLink implements LinkInterface
      * @var string the resource's original filename, in bytes
      */
     private $filename;
+    /**
+     * @var string the target of the link
+     */
+    private $target;
 
     /**
      * Constructs a file link.
@@ -43,13 +47,15 @@ class FileLink implements LinkInterface
      * @param string $kind     the kind of resource it is (document, image, ...)
      * @param string $size     the size of the resource, in bytes
      * @param string $filename the resource's original filename, in bytes
+     * @param string $target   the target of the link
      */
-    public function __construct($url, $kind, $size, $filename)
+    public function __construct($url, $kind, $size, $filename, $target)
     {
         $this->url = $url;
         $this->kind = $kind;
         $this->size = $size;
         $this->filename = $filename;
+        $this->target = $target;
     }
 
     /**
@@ -130,6 +136,18 @@ class FileLink implements LinkInterface
     }
 
     /**
+     * Returns the target of the link
+     *
+     * 
+     *
+     * @return string the target of the link
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
      * Parses a proper bit of unmarshaled JSON into a FileLink object.
      * This is used internally during the unmarshaling of API calls.
      *
@@ -139,11 +157,13 @@ class FileLink implements LinkInterface
      */
     public static function parse($json)
     {
+        $target = property_exists($json, "target") ? $json->target : null;
         return new FileLink(
             $json->file->url,
             $json->file->kind,
             $json->file->size,
-            $json->file->name
+            $json->file->name,
+            $target
         );
     }
 }

--- a/src/Prismic/Fragment/Link/ImageLink.php
+++ b/src/Prismic/Fragment/Link/ImageLink.php
@@ -35,12 +35,13 @@ class ImageLink extends FileLink
      * @param string $kind     the kind of resource it is (document, image, ...)
      * @param string $size     the size of the resource, in bytes
      * @param string $filename the resource's original filename, in bytes
+     * @param string $target   the target of the link
      * @param int    $height   the height of the image
      * @param int    $width    the width of the image
      */
-    public function __construct($url, $kind, $size, $filename, $height, $width)
+    public function __construct($url, $kind, $size, $filename, $target, $height, $width)
     {
-        parent::__construct($url, $kind, $size, $filename);
+        parent::__construct($url, $kind, $size, $filename, $target);
         $this->height = $height;
         $this->width = $width;
     }
@@ -79,11 +80,13 @@ class ImageLink extends FileLink
      */
     public static function parse($json)
     {
+        $target = property_exists($json, "target") ? $json->target : null;
         return new ImageLink(
             $json->image->url,
             $json->image->kind,
             $json->image->size,
             $json->image->name,
+            $target,
             $json->image->height,
             $json->image->width
         );

--- a/src/Prismic/Fragment/Link/WebLink.php
+++ b/src/Prismic/Fragment/Link/WebLink.php
@@ -24,6 +24,10 @@ class WebLink implements LinkInterface
      */
     private $url;
     /**
+     * @var string the target, if known
+     */
+    private $target;
+    /**
      * @var string the content type, if known
      */
     private $maybeContentType;
@@ -32,11 +36,13 @@ class WebLink implements LinkInterface
      * Constructs a media link.
      *
      * @param string $url              the URL of the resource we're linking to online
+     * @param string $target           the target, if known
      * @param string $maybeContentType the content type, if known
      */
-    public function __construct($url, $maybeContentType = null)
+    public function __construct($url, $target = null, $maybeContentType = null)
     {
         $this->url = $url;
+        $this->target = $target;
         $this->maybeContentType = $maybeContentType;
     }
 
@@ -52,7 +58,8 @@ class WebLink implements LinkInterface
      */
     public function asHtml($linkResolver = null)
     {
-        return '<a href="' . $this->url . '">' . $this->url . '</a>';
+        $target = $this->target ? ' target="' . $this->target . '" rel="noopener"' : '';
+        return '<a href="' . $this->url . '"' . $target . '>' . $this->url . '</a>';
     }
 
     /**
@@ -82,6 +89,18 @@ class WebLink implements LinkInterface
     }
 
     /**
+     * Returns the target, if known
+     *
+     * 
+     *
+     * @return string the target, if known
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
      * Returns the content type, if known
      *
      * 
@@ -103,6 +122,7 @@ class WebLink implements LinkInterface
      */
     public static function parse($json)
     {
-        return new WebLink($json->url);
+        $target = property_exists($json, "target") ? $json->target : null;
+        return new WebLink($json->url, $target);
     }
 }

--- a/src/Prismic/Fragment/Span/HyperlinkSpan.php
+++ b/src/Prismic/Fragment/Span/HyperlinkSpan.php
@@ -37,6 +37,10 @@ class HyperlinkSpan implements SpanInterface
      * @var string the label (optional, may be null)
      */
     private $label;
+    /**
+     * @var string the target (optional, may be null)
+     */
+    private $target;
 
     /**
      * Constructs a link span
@@ -45,13 +49,15 @@ class HyperlinkSpan implements SpanInterface
      * @param int           $end   the end of the span
      * @param LinkInterface $link  the link to point to
      * @param string        $label can be null
+     * @param string        $target can be null
      */
-    public function __construct($start, $end, $link, $label = NULL)
+    public function __construct($start, $end, $link, $label = NULL, $target = NULL)
     {
         $this->start = $start;
         $this->end = $end;
         $this->link = $link;
         $this->label = $label;
+        $this->target = $target;
     }
 
     /**
@@ -100,5 +106,17 @@ class HyperlinkSpan implements SpanInterface
     public function getLabel()
     {
         return $this->label;
+    }
+
+    /**
+     * Returns the target
+     *
+     * 
+     *
+     * @return string the target
+     */
+    public function getTarget()
+    {
+        return $this->target;
     }
 }

--- a/src/Prismic/Fragment/StructuredText.php
+++ b/src/Prismic/Fragment/StructuredText.php
@@ -411,6 +411,12 @@ class StructuredText implements FragmentInterface
             $nodeName = 'em';
         } elseif ($element instanceof HyperlinkSpan) {
             $nodeName = 'a';
+            if ($element->getTarget()) {
+                $attributes = array_merge(array(
+                    'target' => $element->getTarget(),
+                    'rel' => 'noopener',
+                ), $attributes);
+            }
             if ($element->getLink() instanceof DocumentLink) {
                 $attributes['href'] = $linkResolver ? $linkResolver($element->getLink()) : '';
             } else {
@@ -460,7 +466,8 @@ class StructuredText implements FragmentInterface
         }
 
         if ("hyperlink" == $type && ($link = self::extractLink($json->data))) {
-            return new HyperlinkSpan($start, $end, $link, $label);
+            $target = $link->getTarget() ? $link->getTarget() : NULL;
+            return new HyperlinkSpan($start, $end, $link, $label, $target);
         }
 
         if ("label" == $type) {

--- a/src/Prismic/LinkResolver.php
+++ b/src/Prismic/LinkResolver.php
@@ -125,7 +125,8 @@ abstract class LinkResolver
             $document->getSlug(),
             $document->getLang(),
             $document->getFragments(),
-            false
+            false,
+            null
         );
     }
 }

--- a/tests/Prismic/FragmentsTest.php
+++ b/tests/Prismic/FragmentsTest.php
@@ -40,6 +40,13 @@ class FragmentsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('<a href="http://prismic.io">http://prismic.io</a>', $link->asHtml());
     }
 
+    public function testWebLinkAsHtmlTargetBlank()
+    {
+        $weblinks = json_decode(file_get_contents(__DIR__.'/../fixtures/weblinks_targetblank.json'));
+        $document = Document::parse($weblinks);
+        $this->assertEquals($document->get('product.link')->asHtml(), '<a href="https://prismic.io" target="_blank" rel="noopener">https://prismic.io</a>');
+    }
+
     public function testSlices()
     {
         $response = json_decode(file_get_contents(__DIR__.'/../fixtures/slices.json'));

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -158,6 +158,13 @@ class StructuredTextTest Extends \PHPUnit_Framework_TestCase
         $this->assertEquals($document->getStructuredText('product.description')->asHtml(), '<p>Link that <a target="_blank" rel="noopener" href="https://prismic.io">opens in a new tab</a>.</p>');
     }
 
+    public function testImageRenderingTargetBlank()
+    {
+        $weblinks = json_decode(file_get_contents(__DIR__.'/../fixtures/weblinks_targetblank.json'));
+        $document = Document::parse($weblinks);
+        $this->assertEquals($document->getStructuredText('product.image_with_link')->asHtml(), '<p class="block-img"><a target="_blank" rel="noopener" href="https://prismic.io"><img src="https://prismic-io.s3.amazonaws.com/serializer-example/aa4f6471fd8b920e92914146a4688154a2d727d6_daria-nepriakhina-1277.jpg" alt="" width="500" height="200"></a></p>');
+    }
+
     public function testStructuredTextHtmlHasBreakTags()
     {
         $this->assertRegExp('`can be rough sometimes\.\s*<br\s*/?>\s*This is after a new line\.`s', $this->structuredText->asHtml());

--- a/tests/Prismic/StructuredTextTest.php
+++ b/tests/Prismic/StructuredTextTest.php
@@ -151,6 +151,13 @@ class StructuredTextTest Extends \PHPUnit_Framework_TestCase
         $this->assertEquals($content, $structuredText->asHtml($linkResolver));
     }
 
+    public function testWebLinkRenderingTargetBlank()
+    {
+        $weblinks = json_decode(file_get_contents(__DIR__.'/../fixtures/weblinks_targetblank.json'));
+        $document = Document::parse($weblinks);
+        $this->assertEquals($document->getStructuredText('product.description')->asHtml(), '<p>Link that <a target="_blank" rel="noopener" href="https://prismic.io">opens in a new tab</a>.</p>');
+    }
+
     public function testStructuredTextHtmlHasBreakTags()
     {
         $this->assertRegExp('`can be rough sometimes\.\s*<br\s*/?>\s*This is after a new line\.`s', $this->structuredText->asHtml());

--- a/tests/fixtures/weblinks_targetblank.json
+++ b/tests/fixtures/weblinks_targetblank.json
@@ -34,6 +34,28 @@
           }
         ]
       },
+      "image_with_link": {
+        "type": "StructuredText",
+        "value": [
+          {
+            "type": "image",
+            "url": "https://prismic-io.s3.amazonaws.com/serializer-example/aa4f6471fd8b920e92914146a4688154a2d727d6_daria-nepriakhina-1277.jpg",
+            "alt": null,
+            "copyright": null,
+            "dimensions": {
+              "width": 500,
+              "height": 200
+            },
+            "linkTo": {
+              "type": "Link.web",
+              "value": {
+                "url": "https://prismic.io",
+                "target": "_blank"
+              }
+            }
+          }
+        ]
+      },
       "link": {
         "type": "Link.web",
         "value": {

--- a/tests/fixtures/weblinks_targetblank.json
+++ b/tests/fixtures/weblinks_targetblank.json
@@ -1,0 +1,46 @@
+{
+  "id": "U30GzQEAADsAGnmX",
+  "type": "product",
+  "href": "https://rudysandbox.prismic.io/api/documents/search?ref=U30G_QEAAC0AGnoB&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22U30GzQEAADsAGnmX%22%29+%5D%5D",
+  "tags": [
+
+  ],
+  "slugs": [
+    "link-to-an",
+    "untitled-document"
+  ],
+  "data": {
+    "product": {
+      "description": {
+        "type": "StructuredText",
+        "value": [
+          {
+            "type": "paragraph",
+            "text": "Link that opens in a new tab.",
+            "spans": [
+              {
+                "start": 10,
+                "end": 28,
+                "type": "hyperlink",
+                "data": {
+                  "type": "Link.web",
+                  "value": {
+                    "url": "https://prismic.io",
+                    "target": "_blank"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "link": {
+        "type": "Link.web",
+        "value": {
+          "url": "https://prismic.io",
+          "target": "_blank"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This updates the kit to add support for the target blank feature.

Here are the changes included:
- Parses the target if included in the link's JSON
- Adds link variable and getLink function to link objects
- Adds target output to WebLink, StructuredText, and ImageView asHtml serializers
- Adds tests for target blank 