### PR TITLE
Detect Preview or Experiment Mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ php:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = 5.5 ]] ; then echo yes | pecl install apcu-4.0.10; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 5.6 ]] ; then echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install apcu; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.1 ]] ; then echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/apc.ini; fi;
   - composer install --dev --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ php:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = 5.5 ]] ; then echo yes | pecl install apcu-4.0.10; fi;
-  - if [[ $TRAVIS_PHP_VERSION = 5.6 ]] ; then echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install apcu; fi;
-  - if [[ $TRAVIS_PHP_VERSION = 7.1 ]] ; then echo "extension=apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/apc.ini; fi;
   - composer install --dev --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ php:
   - 5.5
   - 5.6
   - 7.0.3
+  - 7.1
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION =~ 5.[56] ]] ; then echo yes | pecl install apcu-4.0.10; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 5.5 ]] ; then echo yes | pecl install apcu-4.0.10; fi;
   - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi;
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/apc.ini; fi;
   - composer install --dev --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = 5.5 ]] ; then echo yes | pecl install apcu-4.0.10; fi;
-  - if [[ $TRAVIS_PHP_VERSION = 7.* ]] ; then echo yes | pecl install apcu; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install apcu; fi;
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/apc.ini; fi;
   - composer install --dev --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = 5.5 ]] ; then echo yes | pecl install apcu-4.0.10; fi;
-  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install apcu; fi;
+  - if [[ $TRAVIS_PHP_VERSION = 7.0.3 ]] ; then echo yes | pecl install apcu; fi;
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-add ./tests/apc.ini; fi;
   - composer install --dev --prefer-source
 

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -445,6 +445,26 @@ class Api
     }
 
     /**
+     * Whether the current ref in use is a preview, i.e. the user is in preview mode
+     *
+     * @return bool
+     */
+    public function inPreview()
+    {
+        return null !== $this->getPreviewRef();
+    }
+
+    /**
+     * Whether the current ref in use is an experiment.
+     *
+     * @return bool
+     */
+    public function inExperiment()
+    {
+        return null !== $this->getExperimentRef() && false === $this->inPreview();
+    }
+
+    /**
      * Return the ref currently in use
      *
      * In order of preference, returns the preview cookie, the experiments cookie or the master ref otherwise

--- a/tests/Prismic/ApiTest.php
+++ b/tests/Prismic/ApiTest.php
@@ -94,5 +94,51 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Master-Ref-String', $this->api->ref());
     }
 
+    /**
+     * @depends testCorrectRefIsReturned
+     */
+    public function testInPreviewIsTrueWhenPreviewCookieIsSet()
+    {
+        $cookieValue = 'Preview Ref Cookie Value';
+        $_COOKIE = [
+            'io.prismic.preview' => $cookieValue,
+        ];
+        $this->assertTrue($this->api->inPreview());
+    }
+
+    /**
+     * @depends testCorrectRefIsReturned
+     */
+    public function testInExperimentIsTrueWhenExperimentCookieIsSet()
+    {
+        $cookieValue = 'Experiment Cookie Value';
+        $this->experiments->method('refFromCookie')->willReturn('Experiment Ref');
+        $_COOKIE = [
+            'io.prismic.experiment' => $cookieValue,
+        ];
+        $this->assertTrue($this->api->inExperiment());
+    }
+
+    /**
+     * @depends testInExperimentIsTrueWhenExperimentCookieIsSet
+     */
+    public function testPreviewRefTrumpsExperimentRefWhenSet()
+    {
+        $this->experiments->method('refFromCookie')->willReturn('Experiment Ref');
+        $_COOKIE = [
+            'io.prismic.experiment' => 'Experiment Cookie Value',
+            'io.prismic.preview'    => 'Preview Ref Cookie Value',
+        ];
+        $this->assertTrue($this->api->inPreview());
+        $this->assertFalse($this->api->inExperiment());
+    }
+
+    public function testInPreviewAndInExperimentIsFalseWhenNoCookiesAreSet()
+    {
+        $_COOKIE = [];
+        $this->assertFalse($this->api->inPreview());
+        $this->assertFalse($this->api->inExperiment());
+    }
+
 
 }

--- a/tests/apc.ini
+++ b/tests/apc.ini
@@ -1,3 +1,2 @@
-extension=apc.so
 apc.enable=1
 apc.enable_cli=1

--- a/tests/apc.ini
+++ b/tests/apc.ini
@@ -1,2 +1,3 @@
+extension=apc.so
 apc.enable=1
 apc.enable_cli=1

--- a/tests/apc.ini
+++ b/tests/apc.ini
@@ -1,2 +1,4 @@
+extension=apc.so
+extension=apcu.so
 apc.enable=1
 apc.enable_cli=1


### PR DESCRIPTION
Added 2 methods and tests to determine whether the current session is a preview or an experiment.

The use-case for this is based around the idea that if you are caching rendered content separately to the cached api calls, you'll probably want to know if you're in the middle of a preview so that you can return fresh content to the editor. This is particularly relevant when you're working with content that doesn't directly relate to the document being previewed, for example cached layout elements/content.

Whilst the use case doesn't really hold for experiments, I don't think it hurts to have a helpful accessor that can tell you whether you're in experiment mode or not (?)