### PR TITLE
Update Guzzle version to fix "Warning: count()..."

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.1",


### PR DESCRIPTION
* "Warning: count(): Parameter must be an array or an object that implements
Countable"
* See https://github.com/guzzle/guzzle/issues/1973