### PR TITLE
Updated API to use late static binding

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -69,7 +69,7 @@ class Api
         $this->data        = $data;
         $this->accessToken = $accessToken;
         $this->httpClient  = is_null($httpClient) ? new Client() : $httpClient;
-        $this->cache       = is_null($cache) ? self::defaultCache() : $cache;
+        $this->cache       = is_null($cache) ? static::defaultCache() : $cache;
     }
 
     /**
@@ -83,7 +83,7 @@ class Api
      * @param  ClientInterface $httpClient  Custom Guzzle http client
      * @param  CacheInterface  $cache       Cache implementation
      * @param  int             $apiCacheTTL Max time to keep the API object in cache (in seconds)
-     * @return self
+     * @return static
      */
     public static function get(
         string            $action,
@@ -92,12 +92,12 @@ class Api
         ?CacheInterface   $cache = null,
         int               $apiCacheTTL = 5
     ) : self {
-        $cache    = is_null($cache) ? self::defaultCache() : $cache;
+        $cache    = is_null($cache) ? static::defaultCache() : $cache;
         $cacheKey = $action . (empty($accessToken) ? "" : ("#" . $accessToken));
         $apiData  = $cache->get($cacheKey);
 
         if (is_string($apiData) && ! empty($apiData)) {
-            return new self(unserialize($apiData), $accessToken, $httpClient, $cache);
+            return new static(unserialize($apiData), $accessToken, $httpClient, $cache);
         }
 
         $url = $accessToken ? Utils::buildUrl($action, [ 'access_token' => $accessToken]) : $action;
@@ -110,7 +110,7 @@ class Api
         }
 
         $apiData = ApiData::withJsonString((string) $response->getBody());
-        $api = new self($apiData, $accessToken, $httpClient, $cache);
+        $api = new static($apiData, $accessToken, $httpClient, $cache);
         $cache->set($cacheKey, serialize($apiData), $apiCacheTTL);
 
         return $api;
@@ -350,8 +350,8 @@ class Api
     private function getPreviewRef() :? string
     {
         $cookieNames = [
-            str_replace(['.',' '], '_', self::PREVIEW_COOKIE),
-            self::PREVIEW_COOKIE,
+            str_replace(['.',' '], '_', static::PREVIEW_COOKIE),
+            static::PREVIEW_COOKIE,
         ];
         foreach ($cookieNames as $cookieName) {
             if (isset($_COOKIE[$cookieName])) {
@@ -368,8 +368,8 @@ class Api
     private function getExperimentRef() :? string
     {
         $cookieNames = [
-            str_replace(['.',' '], '_', self::EXPERIMENTS_COOKIE),
-            self::EXPERIMENTS_COOKIE,
+            str_replace(['.',' '], '_', static::EXPERIMENTS_COOKIE),
+            static::EXPERIMENTS_COOKIE,
         ];
         foreach ($cookieNames as $cookieName) {
             if (isset($_COOKIE[$cookieName])) {

--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -350,8 +350,8 @@ class Api
     private function getPreviewRef() :? string
     {
         $cookieNames = [
-            str_replace(['.',' '], '_', static::PREVIEW_COOKIE),
-            static::PREVIEW_COOKIE,
+            str_replace(['.',' '], '_', self::PREVIEW_COOKIE),
+            self::PREVIEW_COOKIE,
         ];
         foreach ($cookieNames as $cookieName) {
             if (isset($_COOKIE[$cookieName])) {
@@ -368,8 +368,8 @@ class Api
     private function getExperimentRef() :? string
     {
         $cookieNames = [
-            str_replace(['.',' '], '_', static::EXPERIMENTS_COOKIE),
-            static::EXPERIMENTS_COOKIE,
+            str_replace(['.',' '], '_', self::EXPERIMENTS_COOKIE),
+            self::EXPERIMENTS_COOKIE,
         ];
         foreach ($cookieNames as $cookieName) {
             if (isset($_COOKIE[$cookieName])) {

--- a/src/Prismic/ApiData.php
+++ b/src/Prismic/ApiData.php
@@ -100,7 +100,7 @@ class ApiData
     /**
      * Return a new ApiData instance from the given JSON string
      * @param string $json
-     * @return self
+     * @return static
      */
     public static function withJsonString(string $json) : self
     {
@@ -111,7 +111,7 @@ class ApiData
                 json_last_error_msg()
             ), json_last_error());
         }
-        return self::withJsonObject($data);
+        return static::withJsonObject($data);
     }
 
     /**

--- a/src/Prismic/Form.php
+++ b/src/Prismic/Form.php
@@ -106,12 +106,12 @@ class Form
     /**
      * Return a new instance from a JSON string
      * @param string $json
-     * @return self
+     * @return static
      */
     public static function withJsonString(string $json) : self
     {
         $data = \json_decode($json);
-        return self::withJsonObject($data);
+        return static::withJsonObject($data);
     }
 
     /**


### PR DESCRIPTION
Using late static binding allows the developers to extend the original Api class and make some customizations.

With this change, developers can rename the cookie by simply doing like this:
```php
class CustomAPI extends Prismic\Api {
    const PREVIEW_COOKIE = "my_custom_cookie";
}

CustomAPI::get('https://project.prismic....');
```

It can also add some logs or manipulation on top of the original class:
```php
class CustomAPI2 extends Prismic\Api {
    public function query($q, $options = array()) {
        $options['lang'] => $_COOKIE['my_custom_locale_cookie'];
        return parent::query($q, $options);
    }
}

CustomAPI::get('https://project.prismic....');
```

These 2 things are not possible currently because the `Api::get()` has the returning forcing to use the `Prismic\Api` class. The only alternative would be doing what the `Api::get` does on the developer side, which is not great and Prismic's updates could break developer's apps.