### PR TITLE
PHP Kit splits spans incorrectly, Or the API is wrong, Or javascript is wrong, or PHP is wrong…

### DIFF
--- a/tests/Prismic/Dom/RichTextTest.php
+++ b/tests/Prismic/Dom/RichTextTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Prismic\Test\Dom;
 
-use Prismic\Test\TestCase;
 use Prismic\Dom\RichText;
 use Prismic\Test\FakeLinkResolver;
+use Prismic\Test\TestCase;
 
 class RichTextTest extends TestCase
 {
@@ -165,5 +165,32 @@ class RichTextTest extends TestCase
 
         $this->assertEquals('', RichText::asHtml($this->richText->empty, $this->linkResolver));
         $this->assertEquals('', RichText::asHtml($this->richText->empty));
+    }
+
+    public function emojiDataProvider()
+    {
+        $expect = [
+            0 => '<p><em>t.</em>🤦‍&zwj;♂️<em>.t</em></p>',
+            1 => '<p><em>t.</em>🚀<em>.t</em></p>',
+            2 => '<p><em>t.</em>🤷&zwj;‍♀<em>.t</em></p>',
+        ];
+        $fixture = json_decode($this->getJsonFixture('emoji.json'));
+        foreach ($fixture->content as $index => $block) {
+            yield [
+                [$block],
+                $expect[$index],
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider emojiDataProvider
+     * @param $block
+     * @param $expect
+     */
+    public function testEmojiAndSpansAreCorrectlyRendered($block, $expect)
+    {
+        $result = RichText::asHtml($block, $this->linkResolver);
+        $this->assertSame($expect, $result);
     }
 }

--- a/tests/fixtures/emoji.json
+++ b/tests/fixtures/emoji.json
@@ -1,0 +1,52 @@
+{
+    "content": [
+        {
+            "type": "paragraph",
+            "text": "t.🤦‍♂️.t",
+            "spans": [
+                {
+                    "start": 0,
+                    "end": 2,
+                    "type": "em"
+                },
+                {
+                    "start": 7,
+                    "end": 9,
+                    "type": "em"
+                }
+            ]
+        },
+        {
+            "type": "paragraph",
+            "text": "t.🚀.t",
+            "spans": [
+                {
+                    "start": 0,
+                    "end": 2,
+                    "type": "em"
+                },
+                {
+                    "start": 4,
+                    "end": 6,
+                    "type": "em"
+                }
+            ]
+        },
+        {
+            "type": "paragraph",
+            "text": "t.🤷‍♀️.t",
+            "spans": [
+                {
+                    "start": 0,
+                    "end": 2,
+                    "type": "em"
+                },
+                {
+                    "start": 7,
+                    "end": 9,
+                    "type": "em"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Who knows?
The fixture represents data returned from the api, where it has been written in the following way: `<em>t.</em>{emoji}<em>.t</em>`.
Javascript gives the case 0 unicode sequence a string length of 5, so the second span starts at index 7 however, PHP's mb_* functions will give that sequence a length of 4. This means that spans are inserted at incorrect positions and leads to `undefined offset` errors.