### PR TITLE
Serialize boolean values

### DIFF
--- a/src/Prismic/SimplePredicate.php
+++ b/src/Prismic/SimplePredicate.php
@@ -52,6 +52,9 @@ class SimplePredicate implements Predicate
      */
     private static function serializeField($value) : string
     {
+        if (is_bool($value)) {
+            return $value ? "true" : "false";
+        }
         if (is_string($value)) {
             return "\"" . $value . "\"";
         }

--- a/tests/Prismic/PredicatesTest.php
+++ b/tests/Prismic/PredicatesTest.php
@@ -8,7 +8,6 @@ use Prismic\Predicates;
 
 class PredicatesTest extends TestCase
 {
-
     public function testAtPredicate()
     {
         $predicate = Predicates::at("document.type", "blog-post");
@@ -55,5 +54,14 @@ class PredicatesTest extends TestCase
     {
         $p = Predicates::near("my.store.coordinates", 40.689757, -74.0451453, 15);
         $this->assertEquals("[:d = geopoint.near(my.store.coordinates, 40.689757, -74.0451453, 15)]", $p->q());
+    }
+
+    public function testBoolean()
+    {
+        $p = Predicates::at("my.product.promote", true);
+        $this->assertEquals('[:d = at(my.product.promote, true)]', $p->q());
+
+        $p = Predicates::at("my.product.promote", false);
+        $this->assertEquals('[:d = at(my.product.promote, false)]', $p->q());
     }
 }


### PR DESCRIPTION
Since the last tagged release (5.1.1) the [boolean field](https://user-guides.prismic.io/en/articles/3456034-boolean-field) has been [released](https://prismic.io/blog/prismic-boolean-fields).

We've made good use of this and have come across an issue where this field is not serialised properly, passing through 1 and 0 instead of true and false.

I've added a simple test around this.