### PR TITLE
Add an Api Factory to make Api mocking easier

### DIFF
--- a/src/Prismic/Api.php
+++ b/src/Prismic/Api.php
@@ -84,6 +84,8 @@ class Api
      * @param  CacheInterface  $cache       Cache implementation
      * @param  int             $apiCacheTTL Max time to keep the API object in cache (in seconds)
      * @return static
+     *
+     * @deprecated Use Prismic\ApiFactory::get instead.
      */
     public static function get(
         string            $action,

--- a/src/Prismic/ApiFactory.php
+++ b/src/Prismic/ApiFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Prismic;
+
+class ApiFactory
+{
+    public function get(...$args): Api
+    {
+        return Api::get(...$args);
+    }
+}


### PR DESCRIPTION
This PR provides a basic ApiFactory to make mocking of the Api client easier.

In the long term this factory should contain all the logic currently found in _Api::get()_.