### PR TITLE
Added support for image links within rich text fields.

### DIFF
--- a/src/Prismic/Dom/RichText.php
+++ b/src/Prismic/Dom/RichText.php
@@ -277,9 +277,13 @@ class RichText
             case 'o-list-item':
                 return nl2br('<li' . $classCode . '>' . $content . '</li>');
             case 'image':
+                $img = '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">';
+
+                $link = property_exists($element, 'linkTo') ? Link::asUrl($element->linkTo, $linkResolver) : null;
+
                 return (
                     '<p class="block-img' . (isset($element->label) ? (' ' . $element->label) : '') . '">' .
-                        '<img src="' . $element->url . '" alt="' . htmlentities($element->alt) . '">' .
+                    ($link ? '<a href="' . $link . '" target="_blank">' . $img . '</a>' : $img) .
                     '</p>'
                 );
             case 'embed':


### PR DESCRIPTION
When wrapping a link around an image element, within Prismic editor, the RichText class does not render out the link around the image.

This is a change to create support for this functionality.